### PR TITLE
Fixes indexing unknown proposals issue

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -18,11 +18,11 @@ schema:
 
 network:
   # Use Tangle network endpoint for Arana Alpha testnet see: https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fstats-dev.api.webb.tools%2Fpublic-ws#/settings/metadata
-  chainId: '0xb8f4e2adae79c37ec55295c71b5f73ae463ab41d97dca0aaac6cfb901bdcf6dc'
+  chainId: '0x8299369d15ba02271e8a79ef89608aa75ce0469c00553f0d95f5e0ad7c819078'
   # using testnet archive node endpoint
-  endpoint: 'wss://tangle-standalone-archive.webb.tools/'
+  # endpoint: 'wss://tangle-standalone-archive.webb.tools/'
   # if you are using docker, uncomment the below line
-  # endpoint: 'ws://host.docker.internal:9944'
+  endpoint: 'ws://host.docker.internal:9944'
   # if you are not using Docker and want to run locally, uncomment the below line
   # endpoint: 'ws://127.0.0.1:9944'
 

--- a/project.yaml
+++ b/project.yaml
@@ -18,11 +18,11 @@ schema:
 
 network:
   # Use Tangle network endpoint for Arana Alpha testnet see: https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fstats-dev.api.webb.tools%2Fpublic-ws#/settings/metadata
-  chainId: '0x8299369d15ba02271e8a79ef89608aa75ce0469c00553f0d95f5e0ad7c819078'
+  chainId: '0x9f617d3da47856cc9718b7c8bfaa573ad5cc8734dfb138c20debad31e0a03a9d'
   # using testnet archive node endpoint
-  # endpoint: 'wss://tangle-standalone-archive.webb.tools/'
+  endpoint: 'wss://tangle-standalone-archive.webb.tools/'
   # if you are using docker, uncomment the below line
-  endpoint: 'ws://host.docker.internal:9944'
+  # endpoint: 'ws://host.docker.internal:9944'
   # if you are not using Docker and want to run locally, uncomment the below line
   # endpoint: 'ws://127.0.0.1:9944'
 

--- a/src/handlers/dkg/dkgProposalHandler/eventHandler.ts
+++ b/src/handlers/dkg/dkgProposalHandler/eventHandler.ts
@@ -53,14 +53,11 @@ export async function dkgProposalHandlerEventHandler(event: SubstrateEvent) {
         const eventData = eventDecoder.as(DKGProposalHandlerSection.ProposalRemoved);
         const proposalId = createProposalId(eventData.targetChain, eventData.key);
         const blockNumber = eventDecoder.blockNumber;
-        // const nonce = String(parseInt(eventData.key.value.toHex()));
         const nonce = createNonceWithProposalType(
           Number(eventData.key.value.toString()),
           Object.keys(JSON.parse(eventData.key.toString()))[0]
         );
         const chainId = Number(eventData.targetChain.value.toString());
-
-        logger.info(`Unsigned Proposal Removed: ${proposalId}`);
         // Create a new removed proposal
         await removeProposal(
           {
@@ -68,7 +65,7 @@ export async function dkgProposalHandlerEventHandler(event: SubstrateEvent) {
             nonce: String(nonce),
             chainId: String(chainId),
             proposalType: dkgPayloadKeyToProposalType(eventData.key),
-            data: eventData.data.toString(),
+            data: '0x00',
           },
           blockNumber
         );
@@ -85,7 +82,6 @@ export async function dkgProposalHandlerEventHandler(event: SubstrateEvent) {
         const proposalId = createProposalId(targetChainId, proposalKey);
         const proposalType = dkgPayloadKeyToProposalType(proposalKey);
         const blockNumber = eventDecoder.metaData.blockNumber;
-        // const nonce = Number(proposalKey.value.toString());
         const nonce = createNonceWithProposalType(
           Number(proposalKey.value.toString()),
           Object.keys(JSON.parse(eventData.key.toString()))[0]

--- a/src/handlers/dkg/dkgProposalHandler/eventHandler.ts
+++ b/src/handlers/dkg/dkgProposalHandler/eventHandler.ts
@@ -67,6 +67,8 @@ export async function dkgProposalHandlerEventHandler(event: SubstrateEvent) {
             blockId: blockNumber,
             nonce: String(nonce),
             chainId: String(chainId),
+            proposalType: dkgPayloadKeyToProposalType(eventData.key),
+            data: eventData.data.toString(),
           },
           blockNumber
         );
@@ -103,6 +105,8 @@ export async function dkgProposalHandlerEventHandler(event: SubstrateEvent) {
             blockId: blockNumber,
             nonce: String(nonce),
             chainId: targetChainId.value.toString(),
+            proposalType,
+            data,
           },
           signature,
           blockNumber

--- a/src/handlers/dkg/dkgProposalHandler/types.ts
+++ b/src/handlers/dkg/dkgProposalHandler/types.ts
@@ -5,5 +5,5 @@ export type DKGProposalHandlerEvent = {
   InvalidProposalSignature: (typeof PalletDkgProposalHandlerEvent)['asInvalidProposalSignature'];
   ProposalSigned: (typeof PalletDkgProposalHandlerEvent)['asProposalSigned'];
   ProposalAdded: Omit<(typeof PalletDkgProposalHandlerEvent)['asProposalSigned'], 'signature'>;
-  ProposalRemoved: Omit<(typeof PalletDkgProposalHandlerEvent)['asProposalSigned'], 'signature' | 'data'>;
+  ProposalRemoved: Omit<(typeof PalletDkgProposalHandlerEvent)['asProposalSigned'], 'signature'>;
 };

--- a/src/handlers/dkg/dkgProposals/eventHandler.ts
+++ b/src/handlers/dkg/dkgProposals/eventHandler.ts
@@ -8,6 +8,7 @@ import {
   addVote,
   approveProposal,
   createNonceWithProposalType,
+  dkgPayloadKeyToProposalType,
   executedProposal,
   failedProposal,
   rejectProposal,
@@ -55,6 +56,8 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
             blockId: eventDecoded.blockNumber,
             nonce: String(nonce),
             chainId: eventData.chainId.toHex(),
+            proposalType: dkgPayloadKeyToProposalType(eventData.key),
+            data: eventData.data.toString(),
           },
           eventData.who.toString(),
           true,
@@ -72,6 +75,8 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
             blockId: eventDecoded.blockNumber,
             nonce: String(nonce),
             chainId: eventData.chainId.toHex(),
+            proposalType: dkgPayloadKeyToProposalType(eventData.key),
+            data: eventData.data.toString(),
           },
           eventData.who.toString(),
           false,
@@ -89,6 +94,8 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
             blockId: eventDecoded.blockNumber,
             nonce: String(nonce),
             chainId: eventData.chainId.toHex(),
+            proposalType: dkgPayloadKeyToProposalType(eventData.key),
+            data: eventData.data.toString(),
           },
           eventDecoded.blockNumber
         );
@@ -104,6 +111,8 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
             blockId: eventDecoded.blockNumber,
             nonce: String(nonce),
             chainId: eventData.chainId.toHex(),
+            proposalType: dkgPayloadKeyToProposalType(eventData.key),
+            data: eventData.data.toString(),
           },
           eventDecoded.blockNumber
         );
@@ -119,6 +128,8 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
             blockId: eventDecoded.blockNumber,
             nonce: String(nonce),
             chainId: eventData.chainId.toString(),
+            proposalType: dkgPayloadKeyToProposalType(eventData.key),
+            data: eventData.data.toString(),
           },
           eventDecoded.blockNumber
         );
@@ -134,6 +145,8 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
             blockId: eventDecoded.blockNumber,
             nonce: String(nonce),
             chainId: eventData.chainId.toString(),
+            proposalType: dkgPayloadKeyToProposalType(eventData.key),
+            data: eventData.data.toString(),
           },
           eventDecoded.blockNumber
         );

--- a/src/utils/proposals/getCurrentQueues.ts
+++ b/src/utils/proposals/getCurrentQueues.ts
@@ -422,7 +422,7 @@ export async function createProposalCounter(blockId: string): Promise<ProposalCo
       proposalType,
     };
   });
-  const parsedUnSigProposals = unSignedProposalsData.map(([key]) => {
+  const parsedUnSigProposals = unSignedProposalsData.map(([key, data]) => {
     const [chainId, dkgKey] = key.args as unknown as [
       typeof WebbProposalsHeaderTypedChainId,
       typeof DkgRuntimePrimitivesProposalDkgPayloadKey
@@ -433,7 +433,7 @@ export async function createProposalCounter(blockId: string): Promise<ProposalCo
       chainId: chainId.value.toString(),
       proposalId: nonce,
       proposalType,
-      data: dkgKey.toString(),
+      data: JSON.parse(data.toString()).proposal.unsigned.data,
     };
   });
   const signedCounter: Partial<Record<ProposalType, ProposalTypeCount>> = {};


### PR DESCRIPTION
### Overview
This PR provides a fix for indexing unknown proposals. Previously, our `ensureProposalItem` function used to create a new proposal if not present and assigned type as `Unknown` always. Now we pass the proposal type when we want to ensure a proposal item.

In stats dapp, BEFORE:

![CleanShot 2023-05-30 at 17 35 15](https://github.com/webb-tools/webb-graphql/assets/53374218/b10188eb-95e5-461d-9180-f8df012a788f)

NOW:

![CleanShot 2023-05-30 at 17 36 45](https://github.com/webb-tools/webb-graphql/assets/53374218/5ae79aaa-b494-4a84-b1c5-d7556b09eeed)