### PR TITLE
Fixes undefined error at proposal vote for event

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -18,7 +18,7 @@ schema:
 
 network:
   # Use Tangle network endpoint for Arana Alpha testnet see: https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fstats-dev.api.webb.tools%2Fpublic-ws#/settings/metadata
-  chainId: '0x6150cf90443bd009f76b915eeba9576252e0371b1349446b69037d7aa28ba9f2'
+  chainId: '0x54bbba5acab7327a66b5522fb3cbe6eeac6b394f6d2c65932c8f589c77e0f760'
   # using testnet archive node endpoint
   endpoint: 'wss://tangle-standalone-archive.webb.tools/'
   # if you are using docker, uncomment the below line

--- a/src/handlers/dkg/dkgProposals/eventHandler.ts
+++ b/src/handlers/dkg/dkgProposals/eventHandler.ts
@@ -56,8 +56,8 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
             blockId: eventDecoded.blockNumber,
             nonce: String(nonce),
             chainId: eventData.chainId.toHex(),
-            proposalType: dkgPayloadKeyToProposalType(eventData.key),
-            data: eventData.data.toString(),
+            proposalType: dkgPayloadKeyToProposalType(eventData.kind),
+            data: '0x00',
           },
           eventData.who.toString(),
           true,
@@ -75,8 +75,8 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
             blockId: eventDecoded.blockNumber,
             nonce: String(nonce),
             chainId: eventData.chainId.toHex(),
-            proposalType: dkgPayloadKeyToProposalType(eventData.key),
-            data: eventData.data.toString(),
+            proposalType: dkgPayloadKeyToProposalType(eventData.kind),
+            data: '0x00',
           },
           eventData.who.toString(),
           false,
@@ -94,8 +94,8 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
             blockId: eventDecoded.blockNumber,
             nonce: String(nonce),
             chainId: eventData.chainId.toHex(),
-            proposalType: dkgPayloadKeyToProposalType(eventData.key),
-            data: eventData.data.toString(),
+            proposalType: dkgPayloadKeyToProposalType(eventData.kind),
+            data: '0x00',
           },
           eventDecoded.blockNumber
         );
@@ -111,8 +111,8 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
             blockId: eventDecoded.blockNumber,
             nonce: String(nonce),
             chainId: eventData.chainId.toHex(),
-            proposalType: dkgPayloadKeyToProposalType(eventData.key),
-            data: eventData.data.toString(),
+            proposalType: dkgPayloadKeyToProposalType(eventData.kind),
+            data: '0x00',
           },
           eventDecoded.blockNumber
         );
@@ -128,8 +128,8 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
             blockId: eventDecoded.blockNumber,
             nonce: String(nonce),
             chainId: eventData.chainId.toString(),
-            proposalType: dkgPayloadKeyToProposalType(eventData.key),
-            data: eventData.data.toString(),
+            proposalType: dkgPayloadKeyToProposalType(eventData.kind),
+            data: '0x00',
           },
           eventDecoded.blockNumber
         );
@@ -145,8 +145,8 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
             blockId: eventDecoded.blockNumber,
             nonce: String(nonce),
             chainId: eventData.chainId.toString(),
-            proposalType: dkgPayloadKeyToProposalType(eventData.key),
-            data: eventData.data.toString(),
+            proposalType: dkgPayloadKeyToProposalType(eventData.kind),
+            data: '0x00',
           },
           eventDecoded.blockNumber
         );

--- a/src/utils/proposals/getCurrentQueues.ts
+++ b/src/utils/proposals/getCurrentQueues.ts
@@ -19,6 +19,7 @@ import {
 const {
   DkgRuntimePrimitivesProposalDkgPayloadKey,
   WebbProposalsHeaderTypedChainId,
+  WebbProposalsProposalProposalKind,
 } = require('@webb-tools/dkg-substrate-types/interfaces/types-lookup');
 import { ensureAccount, ensureBlock } from '../../handlers';
 import { AccountId32 } from '@polkadot/types/interfaces/runtime';
@@ -58,37 +59,39 @@ export interface Proposal {
   signed: Signed;
 }
 
-export function dkgPayloadKeyToProposalType(dkgKey: typeof DkgRuntimePrimitivesProposalDkgPayloadKey): ProposalType {
+export function dkgPayloadKeyToProposalType(
+  dkgKey: typeof DkgRuntimePrimitivesProposalDkgPayloadKey | typeof WebbProposalsProposalProposalKind
+): ProposalType {
   switch (dkgKey.type) {
-    case 'EvmProposal':
+    case 'EvmProposal' || 'Evm':
       return ProposalType.EvmProposal;
-    case 'RefreshVote':
+    case 'RefreshVote' || 'Refresh':
       return ProposalType.RefreshVote;
-    case 'ProposerSetUpdateProposal':
+    case 'ProposerSetUpdateProposal' || 'ProposerSetUpdate':
       return ProposalType.ProposerSetUpdateProposal;
-    case 'AnchorCreateProposal':
+    case 'AnchorCreateProposal' || 'AnchorCreate':
       return ProposalType.AnchorCreateProposal;
-    case 'AnchorUpdateProposal':
+    case 'AnchorUpdateProposal' || 'AnchorUpdate':
       return ProposalType.AnchorUpdateProposal;
-    case 'TokenAddProposal':
+    case 'TokenAddProposal' || 'TokenAdd':
       return ProposalType.TokenAddProposal;
-    case 'TokenRemoveProposal':
+    case 'TokenRemoveProposal' || 'TokenRemove':
       return ProposalType.TokenRemoveProposal;
-    case 'WrappingFeeUpdateProposal':
+    case 'WrappingFeeUpdateProposal' || 'WrappingFeeUpdate':
       return ProposalType.WrappingFeeUpdateProposal;
-    case 'ResourceIdUpdateProposal':
+    case 'ResourceIdUpdateProposal' || 'ResourceIdUpdate':
       return ProposalType.ResourceIdUpdateProposal;
-    case 'RescueTokensProposal':
+    case 'RescueTokensProposal' || 'RescueTokens':
       return ProposalType.RescueTokensProposal;
-    case 'MaxDepositLimitUpdateProposal':
+    case 'MaxDepositLimitUpdateProposal' || 'MaxDepositLimitUpdate':
       return ProposalType.MaxDepositLimitUpdateProposal;
-    case 'MinWithdrawalLimitUpdateProposal':
+    case 'MinWithdrawalLimitUpdateProposal' || 'MinWithdrawalLimitUpdate':
       return ProposalType.MinWithdrawalLimitUpdateProposal;
-    case 'SetVerifierProposal':
+    case 'SetVerifierProposal' || 'SetVerifier':
       return ProposalType.SetVerifierProposal;
-    case 'SetTreasuryHandlerProposal':
+    case 'SetTreasuryHandlerProposal' || 'SetTreasuryHandler':
       return ProposalType.SetTreasuryHandlerProposal;
-    case 'FeeRecipientUpdateProposal':
+    case 'FeeRecipientUpdateProposal' || 'FeeRecipientUpdate':
       return ProposalType.FeeRecipientUpdateProposal;
   }
 }


### PR DESCRIPTION
### Overview
The following `dkgProposalEventHandler` events:

- VoteFor
- VoteAgainst
- ProposalApproved
- ProposalRejected
- ProposalSucceeded
- ProposalFailed

does not provide `key` of type `DkgRuntimePrimitivesProposalDkgPayloadKey` but rather provide `Kind` of type `WebbProposalsProposalProposalKind` in the event data. These two types of data are same which is `Proposal Type` but with different types.

Previously we used to get the proposal type of these above events by passing `key` which doesn't exist leading to undefined error. This PR resolves this issue by passing the right event attribute i.e `Kind`.