### PR TITLE
Re-generate `.graphclient` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,7 +113,6 @@ packages/**/node_modules
 packages/**/build
 packages/**/data
 packages/**/generated
-packages/**/.graphclient
 
 # DKG
 packages/dkg/node_modules

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "nx run-many --all --target=lint:fix",
     "format": "prettier --write \"**/*.{ts,js}\" ",
     "format:check": "prettier --check \"**/*.{ts,js}\" ",
-    "compile": "cd packages/vanchor-client && yarn install && yarn build",
+    "compile": "cd packages/vanchor-client && yarn install",
     "publish:ci": "npm run compile && lerna run compile && lerna publish patch --yes --message 'chore: release new versions' "
   },
   "devDependencies": {

--- a/packages/vanchor-client/.graphclient/index.ts
+++ b/packages/vanchor-client/.graphclient/index.ts
@@ -1,0 +1,5810 @@
+// @ts-nocheck
+import { GraphQLResolveInfo, SelectionSetNode, FieldNode, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+import type { GetMeshOptions } from '@graphql-mesh/runtime';
+import type { YamlConfig } from '@graphql-mesh/types';
+import { PubSub } from '@graphql-mesh/utils';
+import { DefaultLogger } from '@graphql-mesh/utils';
+import MeshCache from "@graphql-mesh/cache-localforage";
+import { fetch as fetchFn } from '@whatwg-node/fetch';
+
+import { MeshResolvedSource } from '@graphql-mesh/runtime';
+import { MeshTransform, MeshPlugin } from '@graphql-mesh/types';
+import GraphqlHandler from "@graphql-mesh/graphql"
+import { parse } from 'graphql';
+import BareMerger from "@graphql-mesh/merger-bare";
+import { createMeshHTTPHandler, MeshHTTPHandler } from '@graphql-mesh/http';
+import { getMesh, ExecuteMeshFn, SubscribeMeshFn, MeshContext as BaseMeshContext, MeshInstance } from '@graphql-mesh/runtime';
+import { MeshStore, FsStoreStorageAdapter } from '@graphql-mesh/store';
+import { path as pathModule } from '@graphql-mesh/cross-helpers';
+import { ImportFn } from '@graphql-mesh/types';
+import type { VanchorTypes } from './sources/vanchor/types';
+import * as importedModule$0 from "./sources/vanchor/introspectionSchema";
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
+
+
+
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  BigDecimal: any;
+  BigInt: any;
+  Bytes: any;
+};
+
+export type Query = {
+  edgeAddition?: Maybe<EdgeAddition>;
+  edgeAdditions: Array<EdgeAddition>;
+  edgeUpdate?: Maybe<EdgeUpdate>;
+  edgeUpdates: Array<EdgeUpdate>;
+  insertion?: Maybe<Insertion>;
+  insertions: Array<Insertion>;
+  newCommitment?: Maybe<NewCommitment>;
+  newCommitments: Array<NewCommitment>;
+  newNullifier?: Maybe<NewNullifier>;
+  newNullifiers: Array<NewNullifier>;
+  publicKey?: Maybe<PublicKey>;
+  publicKeys: Array<PublicKey>;
+  token?: Maybe<Token>;
+  tokens: Array<Token>;
+  externalData?: Maybe<ExternalData>;
+  externalDatas: Array<ExternalData>;
+  publicInputs: Array<PublicInputs>;
+  encryptions: Array<Encryptions>;
+  shieldedTransaction?: Maybe<ShieldedTransaction>;
+  shieldedTransactions: Array<ShieldedTransaction>;
+  vanchorTotalValueLocked?: Maybe<VAnchorTotalValueLocked>;
+  vanchorTotalValueLockeds: Array<VAnchorTotalValueLocked>;
+  vanchorTotalValueLockedByToken?: Maybe<VAnchorTotalValueLockedByToken>;
+  vanchorTotalValueLockedByTokens: Array<VAnchorTotalValueLockedByToken>;
+  vanchorTotalValueLockedEvery15Min?: Maybe<VAnchorTotalValueLockedEvery15Min>;
+  vanchorTotalValueLockedEvery15Mins: Array<VAnchorTotalValueLockedEvery15Min>;
+  vanchorTotalValueLockedByTokenEvery15Min?: Maybe<VAnchorTotalValueLockedByTokenEvery15Min>;
+  vanchorTotalValueLockedByTokenEvery15Mins: Array<VAnchorTotalValueLockedByTokenEvery15Min>;
+  vanchorTotalRelayerFee?: Maybe<VAnchorTotalRelayerFee>;
+  vanchorTotalRelayerFees: Array<VAnchorTotalRelayerFee>;
+  vanchorTotalRelayerFeeByToken?: Maybe<VAnchorTotalRelayerFeeByToken>;
+  vanchorTotalRelayerFeeByTokens: Array<VAnchorTotalRelayerFeeByToken>;
+  vanchorTotalRelayerFee15Min?: Maybe<VAnchorTotalRelayerFee15Min>;
+  vanchorTotalRelayerFee15Mins: Array<VAnchorTotalRelayerFee15Min>;
+  vanchorTotalRelayerFeeByTokenEvery15Min?: Maybe<VAnchorTotalRelayerFeeByTokenEvery15Min>;
+  vanchorTotalRelayerFeeByTokenEvery15Mins: Array<VAnchorTotalRelayerFeeByTokenEvery15Min>;
+  vanchorTotalWrappingFee?: Maybe<VAnchorTotalWrappingFee>;
+  vanchorTotalWrappingFees: Array<VAnchorTotalWrappingFee>;
+  vanchorTotalWrappingFeeByToken?: Maybe<VAnchorTotalWrappingFeeByToken>;
+  vanchorTotalWrappingFeeByTokens: Array<VAnchorTotalWrappingFeeByToken>;
+  vanchorTotalWrappingFee15Min?: Maybe<VAnchorTotalWrappingFee15Min>;
+  vanchorTotalWrappingFee15Mins: Array<VAnchorTotalWrappingFee15Min>;
+  vanchorTotalWrappingFeeByTokenEvery15Min?: Maybe<VAnchorTotalWrappingFeeByTokenEvery15Min>;
+  vanchorTotalWrappingFeeByTokenEvery15Mins: Array<VAnchorTotalWrappingFeeByTokenEvery15Min>;
+  wrappingEventLog?: Maybe<WrappingEventLog>;
+  wrappingEventLogs: Array<WrappingEventLog>;
+  unwrappingEventLog?: Maybe<UnwrappingEventLog>;
+  unwrappingEventLogs: Array<UnwrappingEventLog>;
+  vanchorWithdrawalLog?: Maybe<VAnchorWithdrawalLog>;
+  vanchorWithdrawalLogs: Array<VAnchorWithdrawalLog>;
+  vanchorWithdrawal?: Maybe<VAnchorWithdrawal>;
+  vanchorWithdrawals: Array<VAnchorWithdrawal>;
+  vanchorWithdrawalByToken?: Maybe<VAnchorWithdrawalByToken>;
+  vanchorWithdrawalByTokens: Array<VAnchorWithdrawalByToken>;
+  vanchorWithdrawalEvery15Min?: Maybe<VAnchorWithdrawalEvery15Min>;
+  vanchorWithdrawalEvery15Mins: Array<VAnchorWithdrawalEvery15Min>;
+  vanchorWithdrawalByTokenEvery15Min?: Maybe<VAnchorWithdrawalByTokenEvery15Min>;
+  vanchorWithdrawalByTokenEvery15Mins: Array<VAnchorWithdrawalByTokenEvery15Min>;
+  vanchorDeposit?: Maybe<VAnchorDeposit>;
+  vanchorDeposits: Array<VAnchorDeposit>;
+  vanchorDepositByToken?: Maybe<VAnchorDepositByToken>;
+  vanchorDepositByTokens: Array<VAnchorDepositByToken>;
+  vanchorDepositEvery15Min?: Maybe<VAnchorDepositEvery15Min>;
+  vanchorDepositEvery15Mins: Array<VAnchorDepositEvery15Min>;
+  vanchorDepositByTokenEvery15Min?: Maybe<VAnchorDepositByTokenEvery15Min>;
+  vanchorDepositByTokenEvery15Mins: Array<VAnchorDepositByTokenEvery15Min>;
+  vanchorDepositLog?: Maybe<VAnchorDepositLog>;
+  vanchorDepositLogs: Array<VAnchorDepositLog>;
+  vanchorTransferLog?: Maybe<VAnchorTransferLog>;
+  vanchorTransferLogs: Array<VAnchorTransferLog>;
+  /** Access to subgraph metadata */
+  _meta?: Maybe<_Meta_>;
+};
+
+
+export type QueryedgeAdditionArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryedgeAdditionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<EdgeAddition_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<EdgeAddition_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryedgeUpdateArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryedgeUpdatesArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<EdgeUpdate_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<EdgeUpdate_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryinsertionArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryinsertionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Insertion_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Insertion_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerynewCommitmentArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerynewCommitmentsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<NewCommitment_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<NewCommitment_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerynewNullifierArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerynewNullifiersArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<NewNullifier_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<NewNullifier_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerypublicKeyArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerypublicKeysArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<PublicKey_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<PublicKey_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerytokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerytokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Token_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Token_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryexternalDataArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryexternalDatasArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<ExternalData_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<ExternalData_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerypublicInputsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<PublicInputs_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<PublicInputs_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryencryptionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Encryptions_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Encryptions_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryshieldedTransactionArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryshieldedTransactionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<ShieldedTransaction_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<ShieldedTransaction_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLocked_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLocked_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLockedByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLockedByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLockedEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLockedEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLockedByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLockedByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFeeArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFeesArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFee_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFee_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFeeByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFeeByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFeeByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFeeByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFee15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFee15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFee15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFee15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFeeByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFeeByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFeeByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFeeArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFeesArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFee_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFee_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFeeByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFeeByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFeeByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFeeByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFee15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFee15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFee15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFee15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFeeByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFeeByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFeeByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerywrappingEventLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerywrappingEventLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<WrappingEventLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<WrappingEventLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryunwrappingEventLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryunwrappingEventLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<UnwrappingEventLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<UnwrappingEventLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawal_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawal_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDeposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDeposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTransferLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTransferLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTransferLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTransferLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type Query_metaArgs = {
+  block?: InputMaybe<Block_height>;
+};
+
+export type Subscription = {
+  edgeAddition?: Maybe<EdgeAddition>;
+  edgeAdditions: Array<EdgeAddition>;
+  edgeUpdate?: Maybe<EdgeUpdate>;
+  edgeUpdates: Array<EdgeUpdate>;
+  insertion?: Maybe<Insertion>;
+  insertions: Array<Insertion>;
+  newCommitment?: Maybe<NewCommitment>;
+  newCommitments: Array<NewCommitment>;
+  newNullifier?: Maybe<NewNullifier>;
+  newNullifiers: Array<NewNullifier>;
+  publicKey?: Maybe<PublicKey>;
+  publicKeys: Array<PublicKey>;
+  token?: Maybe<Token>;
+  tokens: Array<Token>;
+  externalData?: Maybe<ExternalData>;
+  externalDatas: Array<ExternalData>;
+  publicInputs: Array<PublicInputs>;
+  encryptions: Array<Encryptions>;
+  shieldedTransaction?: Maybe<ShieldedTransaction>;
+  shieldedTransactions: Array<ShieldedTransaction>;
+  vanchorTotalValueLocked?: Maybe<VAnchorTotalValueLocked>;
+  vanchorTotalValueLockeds: Array<VAnchorTotalValueLocked>;
+  vanchorTotalValueLockedByToken?: Maybe<VAnchorTotalValueLockedByToken>;
+  vanchorTotalValueLockedByTokens: Array<VAnchorTotalValueLockedByToken>;
+  vanchorTotalValueLockedEvery15Min?: Maybe<VAnchorTotalValueLockedEvery15Min>;
+  vanchorTotalValueLockedEvery15Mins: Array<VAnchorTotalValueLockedEvery15Min>;
+  vanchorTotalValueLockedByTokenEvery15Min?: Maybe<VAnchorTotalValueLockedByTokenEvery15Min>;
+  vanchorTotalValueLockedByTokenEvery15Mins: Array<VAnchorTotalValueLockedByTokenEvery15Min>;
+  vanchorTotalRelayerFee?: Maybe<VAnchorTotalRelayerFee>;
+  vanchorTotalRelayerFees: Array<VAnchorTotalRelayerFee>;
+  vanchorTotalRelayerFeeByToken?: Maybe<VAnchorTotalRelayerFeeByToken>;
+  vanchorTotalRelayerFeeByTokens: Array<VAnchorTotalRelayerFeeByToken>;
+  vanchorTotalRelayerFee15Min?: Maybe<VAnchorTotalRelayerFee15Min>;
+  vanchorTotalRelayerFee15Mins: Array<VAnchorTotalRelayerFee15Min>;
+  vanchorTotalRelayerFeeByTokenEvery15Min?: Maybe<VAnchorTotalRelayerFeeByTokenEvery15Min>;
+  vanchorTotalRelayerFeeByTokenEvery15Mins: Array<VAnchorTotalRelayerFeeByTokenEvery15Min>;
+  vanchorTotalWrappingFee?: Maybe<VAnchorTotalWrappingFee>;
+  vanchorTotalWrappingFees: Array<VAnchorTotalWrappingFee>;
+  vanchorTotalWrappingFeeByToken?: Maybe<VAnchorTotalWrappingFeeByToken>;
+  vanchorTotalWrappingFeeByTokens: Array<VAnchorTotalWrappingFeeByToken>;
+  vanchorTotalWrappingFee15Min?: Maybe<VAnchorTotalWrappingFee15Min>;
+  vanchorTotalWrappingFee15Mins: Array<VAnchorTotalWrappingFee15Min>;
+  vanchorTotalWrappingFeeByTokenEvery15Min?: Maybe<VAnchorTotalWrappingFeeByTokenEvery15Min>;
+  vanchorTotalWrappingFeeByTokenEvery15Mins: Array<VAnchorTotalWrappingFeeByTokenEvery15Min>;
+  wrappingEventLog?: Maybe<WrappingEventLog>;
+  wrappingEventLogs: Array<WrappingEventLog>;
+  unwrappingEventLog?: Maybe<UnwrappingEventLog>;
+  unwrappingEventLogs: Array<UnwrappingEventLog>;
+  vanchorWithdrawalLog?: Maybe<VAnchorWithdrawalLog>;
+  vanchorWithdrawalLogs: Array<VAnchorWithdrawalLog>;
+  vanchorWithdrawal?: Maybe<VAnchorWithdrawal>;
+  vanchorWithdrawals: Array<VAnchorWithdrawal>;
+  vanchorWithdrawalByToken?: Maybe<VAnchorWithdrawalByToken>;
+  vanchorWithdrawalByTokens: Array<VAnchorWithdrawalByToken>;
+  vanchorWithdrawalEvery15Min?: Maybe<VAnchorWithdrawalEvery15Min>;
+  vanchorWithdrawalEvery15Mins: Array<VAnchorWithdrawalEvery15Min>;
+  vanchorWithdrawalByTokenEvery15Min?: Maybe<VAnchorWithdrawalByTokenEvery15Min>;
+  vanchorWithdrawalByTokenEvery15Mins: Array<VAnchorWithdrawalByTokenEvery15Min>;
+  vanchorDeposit?: Maybe<VAnchorDeposit>;
+  vanchorDeposits: Array<VAnchorDeposit>;
+  vanchorDepositByToken?: Maybe<VAnchorDepositByToken>;
+  vanchorDepositByTokens: Array<VAnchorDepositByToken>;
+  vanchorDepositEvery15Min?: Maybe<VAnchorDepositEvery15Min>;
+  vanchorDepositEvery15Mins: Array<VAnchorDepositEvery15Min>;
+  vanchorDepositByTokenEvery15Min?: Maybe<VAnchorDepositByTokenEvery15Min>;
+  vanchorDepositByTokenEvery15Mins: Array<VAnchorDepositByTokenEvery15Min>;
+  vanchorDepositLog?: Maybe<VAnchorDepositLog>;
+  vanchorDepositLogs: Array<VAnchorDepositLog>;
+  vanchorTransferLog?: Maybe<VAnchorTransferLog>;
+  vanchorTransferLogs: Array<VAnchorTransferLog>;
+  /** Access to subgraph metadata */
+  _meta?: Maybe<_Meta_>;
+};
+
+
+export type SubscriptionedgeAdditionArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionedgeAdditionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<EdgeAddition_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<EdgeAddition_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionedgeUpdateArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionedgeUpdatesArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<EdgeUpdate_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<EdgeUpdate_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptioninsertionArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptioninsertionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Insertion_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Insertion_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionnewCommitmentArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionnewCommitmentsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<NewCommitment_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<NewCommitment_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionnewNullifierArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionnewNullifiersArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<NewNullifier_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<NewNullifier_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionpublicKeyArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionpublicKeysArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<PublicKey_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<PublicKey_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiontokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiontokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Token_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Token_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionexternalDataArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionexternalDatasArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<ExternalData_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<ExternalData_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionpublicInputsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<PublicInputs_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<PublicInputs_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionencryptionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Encryptions_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Encryptions_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionshieldedTransactionArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionshieldedTransactionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<ShieldedTransaction_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<ShieldedTransaction_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLocked_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLocked_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLockedByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLockedByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLockedEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLockedEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLockedByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLockedByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFeeArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFeesArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFee_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFee_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFeeByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFeeByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFeeByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFeeByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFee15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFee15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFee15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFee15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFeeByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFeeByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFeeByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFeeArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFeesArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFee_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFee_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFeeByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFeeByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFeeByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFeeByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFee15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFee15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFee15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFee15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFeeByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFeeByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFeeByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionwrappingEventLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionwrappingEventLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<WrappingEventLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<WrappingEventLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionunwrappingEventLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionunwrappingEventLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<UnwrappingEventLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<UnwrappingEventLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawal_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawal_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDeposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDeposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTransferLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTransferLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTransferLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTransferLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type Subscription_metaArgs = {
+  block?: InputMaybe<Block_height>;
+};
+
+export type BlockChangedFilter = {
+  number_gte: Scalars['Int'];
+};
+
+export type Block_height = {
+  hash?: InputMaybe<Scalars['Bytes']>;
+  number?: InputMaybe<Scalars['Int']>;
+  number_gte?: InputMaybe<Scalars['Int']>;
+};
+
+export type EdgeAddition = {
+  id: Scalars['Bytes'];
+  chainID: Scalars['BigInt'];
+  latestLeafIndex: Scalars['BigInt'];
+  merkleRoot: Scalars['BigInt'];
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+};
+
+export type EdgeAddition_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  chainID?: InputMaybe<Scalars['BigInt']>;
+  chainID_not?: InputMaybe<Scalars['BigInt']>;
+  chainID_gt?: InputMaybe<Scalars['BigInt']>;
+  chainID_lt?: InputMaybe<Scalars['BigInt']>;
+  chainID_gte?: InputMaybe<Scalars['BigInt']>;
+  chainID_lte?: InputMaybe<Scalars['BigInt']>;
+  chainID_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  chainID_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  latestLeafIndex?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_not?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_gt?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_lt?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_gte?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_lte?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  latestLeafIndex_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  merkleRoot?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_not?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_gt?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_lt?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_gte?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_lte?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  merkleRoot_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<EdgeAddition_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<EdgeAddition_filter>>>;
+};
+
+export type EdgeAddition_orderBy =
+  | 'id'
+  | 'chainID'
+  | 'latestLeafIndex'
+  | 'merkleRoot'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+export type EdgeUpdate = {
+  id: Scalars['Bytes'];
+  chainID: Scalars['BigInt'];
+  latestLeafIndex: Scalars['BigInt'];
+  merkleRoot: Scalars['BigInt'];
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+};
+
+export type EdgeUpdate_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  chainID?: InputMaybe<Scalars['BigInt']>;
+  chainID_not?: InputMaybe<Scalars['BigInt']>;
+  chainID_gt?: InputMaybe<Scalars['BigInt']>;
+  chainID_lt?: InputMaybe<Scalars['BigInt']>;
+  chainID_gte?: InputMaybe<Scalars['BigInt']>;
+  chainID_lte?: InputMaybe<Scalars['BigInt']>;
+  chainID_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  chainID_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  latestLeafIndex?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_not?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_gt?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_lt?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_gte?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_lte?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  latestLeafIndex_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  merkleRoot?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_not?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_gt?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_lt?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_gte?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_lte?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  merkleRoot_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<EdgeUpdate_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<EdgeUpdate_filter>>>;
+};
+
+export type EdgeUpdate_orderBy =
+  | 'id'
+  | 'chainID'
+  | 'latestLeafIndex'
+  | 'merkleRoot'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+export type Encryptions = {
+  id: Scalars['Bytes'];
+  encryptedOutput1: Scalars['Bytes'];
+  encryptedOutput2: Scalars['Bytes'];
+};
+
+export type Encryptions_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_not?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_gt?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_lt?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_gte?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_lte?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  encryptedOutput1_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  encryptedOutput1_contains?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_not_contains?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_not?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_gt?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_lt?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_gte?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_lte?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  encryptedOutput2_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  encryptedOutput2_contains?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Encryptions_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Encryptions_filter>>>;
+};
+
+export type Encryptions_orderBy =
+  | 'id'
+  | 'encryptedOutput1'
+  | 'encryptedOutput2';
+
+export type ExternalData = {
+  id: Scalars['Bytes'];
+  recipient: Scalars['Bytes'];
+  extAmount: Scalars['BigInt'];
+  relayer: Scalars['Bytes'];
+  fee: Scalars['BigInt'];
+  refund: Scalars['BigInt'];
+  token: Scalars['String'];
+};
+
+export type ExternalData_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  recipient?: InputMaybe<Scalars['Bytes']>;
+  recipient_not?: InputMaybe<Scalars['Bytes']>;
+  recipient_gt?: InputMaybe<Scalars['Bytes']>;
+  recipient_lt?: InputMaybe<Scalars['Bytes']>;
+  recipient_gte?: InputMaybe<Scalars['Bytes']>;
+  recipient_lte?: InputMaybe<Scalars['Bytes']>;
+  recipient_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  recipient_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  recipient_contains?: InputMaybe<Scalars['Bytes']>;
+  recipient_not_contains?: InputMaybe<Scalars['Bytes']>;
+  extAmount?: InputMaybe<Scalars['BigInt']>;
+  extAmount_not?: InputMaybe<Scalars['BigInt']>;
+  extAmount_gt?: InputMaybe<Scalars['BigInt']>;
+  extAmount_lt?: InputMaybe<Scalars['BigInt']>;
+  extAmount_gte?: InputMaybe<Scalars['BigInt']>;
+  extAmount_lte?: InputMaybe<Scalars['BigInt']>;
+  extAmount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  extAmount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  relayer?: InputMaybe<Scalars['Bytes']>;
+  relayer_not?: InputMaybe<Scalars['Bytes']>;
+  relayer_gt?: InputMaybe<Scalars['Bytes']>;
+  relayer_lt?: InputMaybe<Scalars['Bytes']>;
+  relayer_gte?: InputMaybe<Scalars['Bytes']>;
+  relayer_lte?: InputMaybe<Scalars['Bytes']>;
+  relayer_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  relayer_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  relayer_contains?: InputMaybe<Scalars['Bytes']>;
+  relayer_not_contains?: InputMaybe<Scalars['Bytes']>;
+  fee?: InputMaybe<Scalars['BigInt']>;
+  fee_not?: InputMaybe<Scalars['BigInt']>;
+  fee_gt?: InputMaybe<Scalars['BigInt']>;
+  fee_lt?: InputMaybe<Scalars['BigInt']>;
+  fee_gte?: InputMaybe<Scalars['BigInt']>;
+  fee_lte?: InputMaybe<Scalars['BigInt']>;
+  fee_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fee_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  refund?: InputMaybe<Scalars['BigInt']>;
+  refund_not?: InputMaybe<Scalars['BigInt']>;
+  refund_gt?: InputMaybe<Scalars['BigInt']>;
+  refund_lt?: InputMaybe<Scalars['BigInt']>;
+  refund_gte?: InputMaybe<Scalars['BigInt']>;
+  refund_lte?: InputMaybe<Scalars['BigInt']>;
+  refund_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  refund_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  token?: InputMaybe<Scalars['String']>;
+  token_not?: InputMaybe<Scalars['String']>;
+  token_gt?: InputMaybe<Scalars['String']>;
+  token_lt?: InputMaybe<Scalars['String']>;
+  token_gte?: InputMaybe<Scalars['String']>;
+  token_lte?: InputMaybe<Scalars['String']>;
+  token_in?: InputMaybe<Array<Scalars['String']>>;
+  token_not_in?: InputMaybe<Array<Scalars['String']>>;
+  token_contains?: InputMaybe<Scalars['String']>;
+  token_contains_nocase?: InputMaybe<Scalars['String']>;
+  token_not_contains?: InputMaybe<Scalars['String']>;
+  token_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  token_starts_with?: InputMaybe<Scalars['String']>;
+  token_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  token_not_starts_with?: InputMaybe<Scalars['String']>;
+  token_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  token_ends_with?: InputMaybe<Scalars['String']>;
+  token_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  token_not_ends_with?: InputMaybe<Scalars['String']>;
+  token_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<ExternalData_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<ExternalData_filter>>>;
+};
+
+export type ExternalData_orderBy =
+  | 'id'
+  | 'recipient'
+  | 'extAmount'
+  | 'relayer'
+  | 'fee'
+  | 'refund'
+  | 'token';
+
+export type Insertion = {
+  id: Scalars['Bytes'];
+  commitment: Scalars['BigInt'];
+  leafIndex: Scalars['BigInt'];
+  timestamp: Scalars['BigInt'];
+  newMerkleRoot: Scalars['BigInt'];
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+};
+
+export type Insertion_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  commitment?: InputMaybe<Scalars['BigInt']>;
+  commitment_not?: InputMaybe<Scalars['BigInt']>;
+  commitment_gt?: InputMaybe<Scalars['BigInt']>;
+  commitment_lt?: InputMaybe<Scalars['BigInt']>;
+  commitment_gte?: InputMaybe<Scalars['BigInt']>;
+  commitment_lte?: InputMaybe<Scalars['BigInt']>;
+  commitment_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  commitment_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  leafIndex?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_not?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_gt?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_lt?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_gte?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_lte?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  leafIndex_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  newMerkleRoot?: InputMaybe<Scalars['BigInt']>;
+  newMerkleRoot_not?: InputMaybe<Scalars['BigInt']>;
+  newMerkleRoot_gt?: InputMaybe<Scalars['BigInt']>;
+  newMerkleRoot_lt?: InputMaybe<Scalars['BigInt']>;
+  newMerkleRoot_gte?: InputMaybe<Scalars['BigInt']>;
+  newMerkleRoot_lte?: InputMaybe<Scalars['BigInt']>;
+  newMerkleRoot_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  newMerkleRoot_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Insertion_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Insertion_filter>>>;
+};
+
+export type Insertion_orderBy =
+  | 'id'
+  | 'commitment'
+  | 'leafIndex'
+  | 'timestamp'
+  | 'newMerkleRoot'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+export type NewCommitment = {
+  id: Scalars['Bytes'];
+  commitment: Scalars['BigInt'];
+  subTreeIndex: Scalars['BigInt'];
+  leafIndex: Scalars['BigInt'];
+  encryptedOutput: Scalars['Bytes'];
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+};
+
+export type NewCommitment_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  commitment?: InputMaybe<Scalars['BigInt']>;
+  commitment_not?: InputMaybe<Scalars['BigInt']>;
+  commitment_gt?: InputMaybe<Scalars['BigInt']>;
+  commitment_lt?: InputMaybe<Scalars['BigInt']>;
+  commitment_gte?: InputMaybe<Scalars['BigInt']>;
+  commitment_lte?: InputMaybe<Scalars['BigInt']>;
+  commitment_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  commitment_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  subTreeIndex?: InputMaybe<Scalars['BigInt']>;
+  subTreeIndex_not?: InputMaybe<Scalars['BigInt']>;
+  subTreeIndex_gt?: InputMaybe<Scalars['BigInt']>;
+  subTreeIndex_lt?: InputMaybe<Scalars['BigInt']>;
+  subTreeIndex_gte?: InputMaybe<Scalars['BigInt']>;
+  subTreeIndex_lte?: InputMaybe<Scalars['BigInt']>;
+  subTreeIndex_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  subTreeIndex_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  leafIndex?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_not?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_gt?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_lt?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_gte?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_lte?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  leafIndex_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  encryptedOutput?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_not?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_gt?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_lt?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_gte?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_lte?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  encryptedOutput_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  encryptedOutput_contains?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_not_contains?: InputMaybe<Scalars['Bytes']>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<NewCommitment_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<NewCommitment_filter>>>;
+};
+
+export type NewCommitment_orderBy =
+  | 'id'
+  | 'commitment'
+  | 'subTreeIndex'
+  | 'leafIndex'
+  | 'encryptedOutput'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+export type NewNullifier = {
+  id: Scalars['Bytes'];
+  nullifier: Scalars['BigInt'];
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+};
+
+export type NewNullifier_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  nullifier?: InputMaybe<Scalars['BigInt']>;
+  nullifier_not?: InputMaybe<Scalars['BigInt']>;
+  nullifier_gt?: InputMaybe<Scalars['BigInt']>;
+  nullifier_lt?: InputMaybe<Scalars['BigInt']>;
+  nullifier_gte?: InputMaybe<Scalars['BigInt']>;
+  nullifier_lte?: InputMaybe<Scalars['BigInt']>;
+  nullifier_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  nullifier_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<NewNullifier_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<NewNullifier_filter>>>;
+};
+
+export type NewNullifier_orderBy =
+  | 'id'
+  | 'nullifier'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+/** Defines the order direction, either ascending or descending */
+export type OrderDirection =
+  | 'asc'
+  | 'desc';
+
+export type PublicInputs = {
+  id: Scalars['Bytes'];
+  roots: Scalars['Bytes'];
+  extensionRoots: Scalars['Bytes'];
+  inputNullifiers: Array<Scalars['BigInt']>;
+  outputCommitments: Array<Scalars['BigInt']>;
+  publicAmount: Scalars['BigInt'];
+  extDataHash: Scalars['BigInt'];
+};
+
+export type PublicInputs_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  roots?: InputMaybe<Scalars['Bytes']>;
+  roots_not?: InputMaybe<Scalars['Bytes']>;
+  roots_gt?: InputMaybe<Scalars['Bytes']>;
+  roots_lt?: InputMaybe<Scalars['Bytes']>;
+  roots_gte?: InputMaybe<Scalars['Bytes']>;
+  roots_lte?: InputMaybe<Scalars['Bytes']>;
+  roots_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  roots_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  roots_contains?: InputMaybe<Scalars['Bytes']>;
+  roots_not_contains?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_not?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_gt?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_lt?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_gte?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_lte?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  extensionRoots_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  extensionRoots_contains?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_not_contains?: InputMaybe<Scalars['Bytes']>;
+  inputNullifiers?: InputMaybe<Array<Scalars['BigInt']>>;
+  inputNullifiers_not?: InputMaybe<Array<Scalars['BigInt']>>;
+  inputNullifiers_contains?: InputMaybe<Array<Scalars['BigInt']>>;
+  inputNullifiers_contains_nocase?: InputMaybe<Array<Scalars['BigInt']>>;
+  inputNullifiers_not_contains?: InputMaybe<Array<Scalars['BigInt']>>;
+  inputNullifiers_not_contains_nocase?: InputMaybe<Array<Scalars['BigInt']>>;
+  outputCommitments?: InputMaybe<Array<Scalars['BigInt']>>;
+  outputCommitments_not?: InputMaybe<Array<Scalars['BigInt']>>;
+  outputCommitments_contains?: InputMaybe<Array<Scalars['BigInt']>>;
+  outputCommitments_contains_nocase?: InputMaybe<Array<Scalars['BigInt']>>;
+  outputCommitments_not_contains?: InputMaybe<Array<Scalars['BigInt']>>;
+  outputCommitments_not_contains_nocase?: InputMaybe<Array<Scalars['BigInt']>>;
+  publicAmount?: InputMaybe<Scalars['BigInt']>;
+  publicAmount_not?: InputMaybe<Scalars['BigInt']>;
+  publicAmount_gt?: InputMaybe<Scalars['BigInt']>;
+  publicAmount_lt?: InputMaybe<Scalars['BigInt']>;
+  publicAmount_gte?: InputMaybe<Scalars['BigInt']>;
+  publicAmount_lte?: InputMaybe<Scalars['BigInt']>;
+  publicAmount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  publicAmount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  extDataHash?: InputMaybe<Scalars['BigInt']>;
+  extDataHash_not?: InputMaybe<Scalars['BigInt']>;
+  extDataHash_gt?: InputMaybe<Scalars['BigInt']>;
+  extDataHash_lt?: InputMaybe<Scalars['BigInt']>;
+  extDataHash_gte?: InputMaybe<Scalars['BigInt']>;
+  extDataHash_lte?: InputMaybe<Scalars['BigInt']>;
+  extDataHash_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  extDataHash_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<PublicInputs_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<PublicInputs_filter>>>;
+};
+
+export type PublicInputs_orderBy =
+  | 'id'
+  | 'roots'
+  | 'extensionRoots'
+  | 'inputNullifiers'
+  | 'outputCommitments'
+  | 'publicAmount'
+  | 'extDataHash';
+
+export type PublicKey = {
+  id: Scalars['Bytes'];
+  owner: Scalars['Bytes'];
+  key: Scalars['Bytes'];
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+};
+
+export type PublicKey_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  owner?: InputMaybe<Scalars['Bytes']>;
+  owner_not?: InputMaybe<Scalars['Bytes']>;
+  owner_gt?: InputMaybe<Scalars['Bytes']>;
+  owner_lt?: InputMaybe<Scalars['Bytes']>;
+  owner_gte?: InputMaybe<Scalars['Bytes']>;
+  owner_lte?: InputMaybe<Scalars['Bytes']>;
+  owner_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  owner_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  owner_contains?: InputMaybe<Scalars['Bytes']>;
+  owner_not_contains?: InputMaybe<Scalars['Bytes']>;
+  key?: InputMaybe<Scalars['Bytes']>;
+  key_not?: InputMaybe<Scalars['Bytes']>;
+  key_gt?: InputMaybe<Scalars['Bytes']>;
+  key_lt?: InputMaybe<Scalars['Bytes']>;
+  key_gte?: InputMaybe<Scalars['Bytes']>;
+  key_lte?: InputMaybe<Scalars['Bytes']>;
+  key_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  key_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  key_contains?: InputMaybe<Scalars['Bytes']>;
+  key_not_contains?: InputMaybe<Scalars['Bytes']>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<PublicKey_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<PublicKey_filter>>>;
+};
+
+export type PublicKey_orderBy =
+  | 'id'
+  | 'owner'
+  | 'key'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+export type ShieldedTransaction = {
+  id: Scalars['Bytes'];
+  vanchor: Scalars['Bytes'];
+  sender: Scalars['Bytes'];
+  value: Scalars['BigInt'];
+  proof: Scalars['Bytes'];
+  auxPublicInputs: Scalars['Bytes'];
+  externalData: ExternalData;
+  publicInputs: PublicInputs;
+  encryptions: Encryptions;
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+  subgraphUrl: Scalars['String'];
+};
+
+export type ShieldedTransaction_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  vanchor?: InputMaybe<Scalars['Bytes']>;
+  vanchor_not?: InputMaybe<Scalars['Bytes']>;
+  vanchor_gt?: InputMaybe<Scalars['Bytes']>;
+  vanchor_lt?: InputMaybe<Scalars['Bytes']>;
+  vanchor_gte?: InputMaybe<Scalars['Bytes']>;
+  vanchor_lte?: InputMaybe<Scalars['Bytes']>;
+  vanchor_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vanchor_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vanchor_contains?: InputMaybe<Scalars['Bytes']>;
+  vanchor_not_contains?: InputMaybe<Scalars['Bytes']>;
+  sender?: InputMaybe<Scalars['Bytes']>;
+  sender_not?: InputMaybe<Scalars['Bytes']>;
+  sender_gt?: InputMaybe<Scalars['Bytes']>;
+  sender_lt?: InputMaybe<Scalars['Bytes']>;
+  sender_gte?: InputMaybe<Scalars['Bytes']>;
+  sender_lte?: InputMaybe<Scalars['Bytes']>;
+  sender_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  sender_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  sender_contains?: InputMaybe<Scalars['Bytes']>;
+  sender_not_contains?: InputMaybe<Scalars['Bytes']>;
+  value?: InputMaybe<Scalars['BigInt']>;
+  value_not?: InputMaybe<Scalars['BigInt']>;
+  value_gt?: InputMaybe<Scalars['BigInt']>;
+  value_lt?: InputMaybe<Scalars['BigInt']>;
+  value_gte?: InputMaybe<Scalars['BigInt']>;
+  value_lte?: InputMaybe<Scalars['BigInt']>;
+  value_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  value_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  proof?: InputMaybe<Scalars['Bytes']>;
+  proof_not?: InputMaybe<Scalars['Bytes']>;
+  proof_gt?: InputMaybe<Scalars['Bytes']>;
+  proof_lt?: InputMaybe<Scalars['Bytes']>;
+  proof_gte?: InputMaybe<Scalars['Bytes']>;
+  proof_lte?: InputMaybe<Scalars['Bytes']>;
+  proof_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  proof_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  proof_contains?: InputMaybe<Scalars['Bytes']>;
+  proof_not_contains?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_not?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_gt?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_lt?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_gte?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_lte?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  auxPublicInputs_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  auxPublicInputs_contains?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_not_contains?: InputMaybe<Scalars['Bytes']>;
+  externalData?: InputMaybe<Scalars['String']>;
+  externalData_not?: InputMaybe<Scalars['String']>;
+  externalData_gt?: InputMaybe<Scalars['String']>;
+  externalData_lt?: InputMaybe<Scalars['String']>;
+  externalData_gte?: InputMaybe<Scalars['String']>;
+  externalData_lte?: InputMaybe<Scalars['String']>;
+  externalData_in?: InputMaybe<Array<Scalars['String']>>;
+  externalData_not_in?: InputMaybe<Array<Scalars['String']>>;
+  externalData_contains?: InputMaybe<Scalars['String']>;
+  externalData_contains_nocase?: InputMaybe<Scalars['String']>;
+  externalData_not_contains?: InputMaybe<Scalars['String']>;
+  externalData_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  externalData_starts_with?: InputMaybe<Scalars['String']>;
+  externalData_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  externalData_not_starts_with?: InputMaybe<Scalars['String']>;
+  externalData_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  externalData_ends_with?: InputMaybe<Scalars['String']>;
+  externalData_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  externalData_not_ends_with?: InputMaybe<Scalars['String']>;
+  externalData_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  externalData_?: InputMaybe<ExternalData_filter>;
+  publicInputs?: InputMaybe<Scalars['String']>;
+  publicInputs_not?: InputMaybe<Scalars['String']>;
+  publicInputs_gt?: InputMaybe<Scalars['String']>;
+  publicInputs_lt?: InputMaybe<Scalars['String']>;
+  publicInputs_gte?: InputMaybe<Scalars['String']>;
+  publicInputs_lte?: InputMaybe<Scalars['String']>;
+  publicInputs_in?: InputMaybe<Array<Scalars['String']>>;
+  publicInputs_not_in?: InputMaybe<Array<Scalars['String']>>;
+  publicInputs_contains?: InputMaybe<Scalars['String']>;
+  publicInputs_contains_nocase?: InputMaybe<Scalars['String']>;
+  publicInputs_not_contains?: InputMaybe<Scalars['String']>;
+  publicInputs_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  publicInputs_starts_with?: InputMaybe<Scalars['String']>;
+  publicInputs_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  publicInputs_not_starts_with?: InputMaybe<Scalars['String']>;
+  publicInputs_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  publicInputs_ends_with?: InputMaybe<Scalars['String']>;
+  publicInputs_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  publicInputs_not_ends_with?: InputMaybe<Scalars['String']>;
+  publicInputs_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  publicInputs_?: InputMaybe<PublicInputs_filter>;
+  encryptions?: InputMaybe<Scalars['String']>;
+  encryptions_not?: InputMaybe<Scalars['String']>;
+  encryptions_gt?: InputMaybe<Scalars['String']>;
+  encryptions_lt?: InputMaybe<Scalars['String']>;
+  encryptions_gte?: InputMaybe<Scalars['String']>;
+  encryptions_lte?: InputMaybe<Scalars['String']>;
+  encryptions_in?: InputMaybe<Array<Scalars['String']>>;
+  encryptions_not_in?: InputMaybe<Array<Scalars['String']>>;
+  encryptions_contains?: InputMaybe<Scalars['String']>;
+  encryptions_contains_nocase?: InputMaybe<Scalars['String']>;
+  encryptions_not_contains?: InputMaybe<Scalars['String']>;
+  encryptions_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  encryptions_starts_with?: InputMaybe<Scalars['String']>;
+  encryptions_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  encryptions_not_starts_with?: InputMaybe<Scalars['String']>;
+  encryptions_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  encryptions_ends_with?: InputMaybe<Scalars['String']>;
+  encryptions_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  encryptions_not_ends_with?: InputMaybe<Scalars['String']>;
+  encryptions_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  encryptions_?: InputMaybe<Encryptions_filter>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<ShieldedTransaction_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<ShieldedTransaction_filter>>>;
+};
+
+export type ShieldedTransaction_orderBy =
+  | 'id'
+  | 'vanchor'
+  | 'sender'
+  | 'value'
+  | 'proof'
+  | 'auxPublicInputs'
+  | 'externalData'
+  | 'externalData__id'
+  | 'externalData__recipient'
+  | 'externalData__extAmount'
+  | 'externalData__relayer'
+  | 'externalData__fee'
+  | 'externalData__refund'
+  | 'externalData__token'
+  | 'publicInputs'
+  | 'publicInputs__id'
+  | 'publicInputs__roots'
+  | 'publicInputs__extensionRoots'
+  | 'publicInputs__publicAmount'
+  | 'publicInputs__extDataHash'
+  | 'encryptions'
+  | 'encryptions__id'
+  | 'encryptions__encryptedOutput1'
+  | 'encryptions__encryptedOutput2'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+export type Token = {
+  id: Scalars['Bytes'];
+  address: Scalars['Bytes'];
+  decimals: Scalars['Int'];
+  name: Scalars['String'];
+  symbol: Scalars['String'];
+};
+
+export type Token_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  address?: InputMaybe<Scalars['Bytes']>;
+  address_not?: InputMaybe<Scalars['Bytes']>;
+  address_gt?: InputMaybe<Scalars['Bytes']>;
+  address_lt?: InputMaybe<Scalars['Bytes']>;
+  address_gte?: InputMaybe<Scalars['Bytes']>;
+  address_lte?: InputMaybe<Scalars['Bytes']>;
+  address_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  address_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  address_contains?: InputMaybe<Scalars['Bytes']>;
+  address_not_contains?: InputMaybe<Scalars['Bytes']>;
+  decimals?: InputMaybe<Scalars['Int']>;
+  decimals_not?: InputMaybe<Scalars['Int']>;
+  decimals_gt?: InputMaybe<Scalars['Int']>;
+  decimals_lt?: InputMaybe<Scalars['Int']>;
+  decimals_gte?: InputMaybe<Scalars['Int']>;
+  decimals_lte?: InputMaybe<Scalars['Int']>;
+  decimals_in?: InputMaybe<Array<Scalars['Int']>>;
+  decimals_not_in?: InputMaybe<Array<Scalars['Int']>>;
+  name?: InputMaybe<Scalars['String']>;
+  name_not?: InputMaybe<Scalars['String']>;
+  name_gt?: InputMaybe<Scalars['String']>;
+  name_lt?: InputMaybe<Scalars['String']>;
+  name_gte?: InputMaybe<Scalars['String']>;
+  name_lte?: InputMaybe<Scalars['String']>;
+  name_in?: InputMaybe<Array<Scalars['String']>>;
+  name_not_in?: InputMaybe<Array<Scalars['String']>>;
+  name_contains?: InputMaybe<Scalars['String']>;
+  name_contains_nocase?: InputMaybe<Scalars['String']>;
+  name_not_contains?: InputMaybe<Scalars['String']>;
+  name_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  name_starts_with?: InputMaybe<Scalars['String']>;
+  name_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  name_not_starts_with?: InputMaybe<Scalars['String']>;
+  name_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  name_ends_with?: InputMaybe<Scalars['String']>;
+  name_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  name_not_ends_with?: InputMaybe<Scalars['String']>;
+  name_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  symbol?: InputMaybe<Scalars['String']>;
+  symbol_not?: InputMaybe<Scalars['String']>;
+  symbol_gt?: InputMaybe<Scalars['String']>;
+  symbol_lt?: InputMaybe<Scalars['String']>;
+  symbol_gte?: InputMaybe<Scalars['String']>;
+  symbol_lte?: InputMaybe<Scalars['String']>;
+  symbol_in?: InputMaybe<Array<Scalars['String']>>;
+  symbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  symbol_contains?: InputMaybe<Scalars['String']>;
+  symbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  symbol_not_contains?: InputMaybe<Scalars['String']>;
+  symbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  symbol_starts_with?: InputMaybe<Scalars['String']>;
+  symbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  symbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  symbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  symbol_ends_with?: InputMaybe<Scalars['String']>;
+  symbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  symbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  symbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Token_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Token_filter>>>;
+};
+
+export type Token_orderBy =
+  | 'id'
+  | 'address'
+  | 'decimals'
+  | 'name'
+  | 'symbol';
+
+export type UnwrappingEventLog = {
+  id: Scalars['String'];
+  sender: Scalars['Bytes'];
+  recipient: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  amount: Scalars['BigInt'];
+  timestamp: Scalars['BigInt'];
+};
+
+export type UnwrappingEventLog_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  sender?: InputMaybe<Scalars['Bytes']>;
+  sender_not?: InputMaybe<Scalars['Bytes']>;
+  sender_gt?: InputMaybe<Scalars['Bytes']>;
+  sender_lt?: InputMaybe<Scalars['Bytes']>;
+  sender_gte?: InputMaybe<Scalars['Bytes']>;
+  sender_lte?: InputMaybe<Scalars['Bytes']>;
+  sender_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  sender_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  sender_contains?: InputMaybe<Scalars['Bytes']>;
+  sender_not_contains?: InputMaybe<Scalars['Bytes']>;
+  recipient?: InputMaybe<Scalars['Bytes']>;
+  recipient_not?: InputMaybe<Scalars['Bytes']>;
+  recipient_gt?: InputMaybe<Scalars['Bytes']>;
+  recipient_lt?: InputMaybe<Scalars['Bytes']>;
+  recipient_gte?: InputMaybe<Scalars['Bytes']>;
+  recipient_lte?: InputMaybe<Scalars['Bytes']>;
+  recipient_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  recipient_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  recipient_contains?: InputMaybe<Scalars['Bytes']>;
+  recipient_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  amount?: InputMaybe<Scalars['BigInt']>;
+  amount_not?: InputMaybe<Scalars['BigInt']>;
+  amount_gt?: InputMaybe<Scalars['BigInt']>;
+  amount_lt?: InputMaybe<Scalars['BigInt']>;
+  amount_gte?: InputMaybe<Scalars['BigInt']>;
+  amount_lte?: InputMaybe<Scalars['BigInt']>;
+  amount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  amount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<UnwrappingEventLog_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<UnwrappingEventLog_filter>>>;
+};
+
+export type UnwrappingEventLog_orderBy =
+  | 'id'
+  | 'sender'
+  | 'recipient'
+  | 'tokenAddress'
+  | 'amount'
+  | 'timestamp';
+
+export type VAnchorDeposit = {
+  id: Scalars['String'];
+  deposit: Scalars['BigInt'];
+  averageDeposit: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorDepositByToken = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  deposit: Scalars['BigInt'];
+  averageDeposit: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorDepositByTokenEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  deposit: Scalars['BigInt'];
+  averageDeposit: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorDepositByTokenEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit?: InputMaybe<Scalars['BigInt']>;
+  deposit_not?: InputMaybe<Scalars['BigInt']>;
+  deposit_gt?: InputMaybe<Scalars['BigInt']>;
+  deposit_lt?: InputMaybe<Scalars['BigInt']>;
+  deposit_gte?: InputMaybe<Scalars['BigInt']>;
+  deposit_lte?: InputMaybe<Scalars['BigInt']>;
+  deposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_not?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorDepositByTokenEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorDepositByTokenEvery15Min_filter>>>;
+};
+
+export type VAnchorDepositByTokenEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'startInterval'
+  | 'endInterval'
+  | 'deposit'
+  | 'averageDeposit'
+  | 'totalCount';
+
+export type VAnchorDepositByToken_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  deposit?: InputMaybe<Scalars['BigInt']>;
+  deposit_not?: InputMaybe<Scalars['BigInt']>;
+  deposit_gt?: InputMaybe<Scalars['BigInt']>;
+  deposit_lt?: InputMaybe<Scalars['BigInt']>;
+  deposit_gte?: InputMaybe<Scalars['BigInt']>;
+  deposit_lte?: InputMaybe<Scalars['BigInt']>;
+  deposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_not?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorDepositByToken_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorDepositByToken_filter>>>;
+};
+
+export type VAnchorDepositByToken_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'deposit'
+  | 'averageDeposit'
+  | 'totalCount';
+
+export type VAnchorDepositEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  deposit: Scalars['BigInt'];
+  averageDeposit: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorDepositEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit?: InputMaybe<Scalars['BigInt']>;
+  deposit_not?: InputMaybe<Scalars['BigInt']>;
+  deposit_gt?: InputMaybe<Scalars['BigInt']>;
+  deposit_lt?: InputMaybe<Scalars['BigInt']>;
+  deposit_gte?: InputMaybe<Scalars['BigInt']>;
+  deposit_lte?: InputMaybe<Scalars['BigInt']>;
+  deposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_not?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorDepositEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorDepositEvery15Min_filter>>>;
+};
+
+export type VAnchorDepositEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'startInterval'
+  | 'endInterval'
+  | 'deposit'
+  | 'averageDeposit'
+  | 'totalCount';
+
+export type VAnchorDepositLog = {
+  id: Scalars['String'];
+  deposit: Scalars['BigInt'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  timestamp: Scalars['BigInt'];
+};
+
+export type VAnchorDepositLog_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  deposit?: InputMaybe<Scalars['BigInt']>;
+  deposit_not?: InputMaybe<Scalars['BigInt']>;
+  deposit_gt?: InputMaybe<Scalars['BigInt']>;
+  deposit_lt?: InputMaybe<Scalars['BigInt']>;
+  deposit_gte?: InputMaybe<Scalars['BigInt']>;
+  deposit_lte?: InputMaybe<Scalars['BigInt']>;
+  deposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorDepositLog_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorDepositLog_filter>>>;
+};
+
+export type VAnchorDepositLog_orderBy =
+  | 'id'
+  | 'deposit'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'timestamp';
+
+export type VAnchorDeposit_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  deposit?: InputMaybe<Scalars['BigInt']>;
+  deposit_not?: InputMaybe<Scalars['BigInt']>;
+  deposit_gt?: InputMaybe<Scalars['BigInt']>;
+  deposit_lt?: InputMaybe<Scalars['BigInt']>;
+  deposit_gte?: InputMaybe<Scalars['BigInt']>;
+  deposit_lte?: InputMaybe<Scalars['BigInt']>;
+  deposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_not?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorDeposit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorDeposit_filter>>>;
+};
+
+export type VAnchorDeposit_orderBy =
+  | 'id'
+  | 'deposit'
+  | 'averageDeposit'
+  | 'totalCount';
+
+export type VAnchorTotalRelayerFee = {
+  id: Scalars['String'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalRelayerFee15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalRelayerFee15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFee15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFee15Min_filter>>>;
+};
+
+export type VAnchorTotalRelayerFee15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'startInterval'
+  | 'endInterval'
+  | 'fees';
+
+export type VAnchorTotalRelayerFeeByToken = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  tokenAddress: Scalars['Bytes'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalRelayerFeeByTokenEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalRelayerFeeByTokenEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFeeByTokenEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFeeByTokenEvery15Min_filter>>>;
+};
+
+export type VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'startInterval'
+  | 'endInterval'
+  | 'fees';
+
+export type VAnchorTotalRelayerFeeByToken_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFeeByToken_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFeeByToken_filter>>>;
+};
+
+export type VAnchorTotalRelayerFeeByToken_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenSymbol'
+  | 'tokenAddress'
+  | 'fees';
+
+export type VAnchorTotalRelayerFee_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFee_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFee_filter>>>;
+};
+
+export type VAnchorTotalRelayerFee_orderBy =
+  | 'id'
+  | 'fees';
+
+export type VAnchorTotalValueLocked = {
+  id: Scalars['String'];
+  totalValueLocked: Scalars['BigInt'];
+};
+
+export type VAnchorTotalValueLockedByToken = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  totalValueLocked: Scalars['BigInt'];
+};
+
+export type VAnchorTotalValueLockedByTokenEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  totalValueLocked: Scalars['BigInt'];
+};
+
+export type VAnchorTotalValueLockedByTokenEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalValueLocked?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_not?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalValueLocked_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLockedByTokenEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLockedByTokenEvery15Min_filter>>>;
+};
+
+export type VAnchorTotalValueLockedByTokenEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'startInterval'
+  | 'endInterval'
+  | 'totalValueLocked';
+
+export type VAnchorTotalValueLockedByToken_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  totalValueLocked?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_not?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalValueLocked_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLockedByToken_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLockedByToken_filter>>>;
+};
+
+export type VAnchorTotalValueLockedByToken_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'totalValueLocked';
+
+export type VAnchorTotalValueLockedEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  totalValueLocked: Scalars['BigInt'];
+};
+
+export type VAnchorTotalValueLockedEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalValueLocked?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_not?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalValueLocked_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLockedEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLockedEvery15Min_filter>>>;
+};
+
+export type VAnchorTotalValueLockedEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'startInterval'
+  | 'endInterval'
+  | 'totalValueLocked';
+
+export type VAnchorTotalValueLocked_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  totalValueLocked?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_not?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalValueLocked_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLocked_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLocked_filter>>>;
+};
+
+export type VAnchorTotalValueLocked_orderBy =
+  | 'id'
+  | 'totalValueLocked';
+
+export type VAnchorTotalWrappingFee = {
+  id: Scalars['String'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalWrappingFee15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalWrappingFee15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFee15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFee15Min_filter>>>;
+};
+
+export type VAnchorTotalWrappingFee15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'startInterval'
+  | 'endInterval'
+  | 'fees';
+
+export type VAnchorTotalWrappingFeeByToken = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  tokenAddress: Scalars['Bytes'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalWrappingFeeByTokenEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalWrappingFeeByTokenEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFeeByTokenEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFeeByTokenEvery15Min_filter>>>;
+};
+
+export type VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'startInterval'
+  | 'endInterval'
+  | 'fees';
+
+export type VAnchorTotalWrappingFeeByToken_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFeeByToken_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFeeByToken_filter>>>;
+};
+
+export type VAnchorTotalWrappingFeeByToken_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenSymbol'
+  | 'tokenAddress'
+  | 'fees';
+
+export type VAnchorTotalWrappingFee_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFee_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFee_filter>>>;
+};
+
+export type VAnchorTotalWrappingFee_orderBy =
+  | 'id'
+  | 'fees';
+
+export type VAnchorTransferLog = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  timestamp: Scalars['BigInt'];
+};
+
+export type VAnchorTransferLog_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTransferLog_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTransferLog_filter>>>;
+};
+
+export type VAnchorTransferLog_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'timestamp';
+
+export type VAnchorWithdrawal = {
+  id: Scalars['String'];
+  withdrawal: Scalars['BigInt'];
+  averageWithdrawal: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorWithdrawalByToken = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  withdrawal: Scalars['BigInt'];
+  averageWithdrawal: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorWithdrawalByTokenEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  withdrawal: Scalars['BigInt'];
+  averageWithdrawal: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorWithdrawalByTokenEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalByTokenEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalByTokenEvery15Min_filter>>>;
+};
+
+export type VAnchorWithdrawalByTokenEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'startInterval'
+  | 'endInterval'
+  | 'withdrawal'
+  | 'averageWithdrawal'
+  | 'totalCount';
+
+export type VAnchorWithdrawalByToken_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  withdrawal?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalByToken_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalByToken_filter>>>;
+};
+
+export type VAnchorWithdrawalByToken_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'withdrawal'
+  | 'averageWithdrawal'
+  | 'totalCount';
+
+export type VAnchorWithdrawalEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  withdrawal: Scalars['BigInt'];
+  averageWithdrawal: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorWithdrawalEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalEvery15Min_filter>>>;
+};
+
+export type VAnchorWithdrawalEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'startInterval'
+  | 'endInterval'
+  | 'withdrawal'
+  | 'averageWithdrawal'
+  | 'totalCount';
+
+export type VAnchorWithdrawalLog = {
+  id: Scalars['String'];
+  withdrawal: Scalars['BigInt'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  timestamp: Scalars['BigInt'];
+};
+
+export type VAnchorWithdrawalLog_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  withdrawal?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalLog_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalLog_filter>>>;
+};
+
+export type VAnchorWithdrawalLog_orderBy =
+  | 'id'
+  | 'withdrawal'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'timestamp';
+
+export type VAnchorWithdrawal_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  withdrawal?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorWithdrawal_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorWithdrawal_filter>>>;
+};
+
+export type VAnchorWithdrawal_orderBy =
+  | 'id'
+  | 'withdrawal'
+  | 'averageWithdrawal'
+  | 'totalCount';
+
+export type WrappingEventLog = {
+  id: Scalars['String'];
+  sender: Scalars['Bytes'];
+  recipient: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  wrappingFee: Scalars['BigInt'];
+  afterFeeAmount: Scalars['BigInt'];
+  timestamp: Scalars['BigInt'];
+};
+
+export type WrappingEventLog_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  sender?: InputMaybe<Scalars['Bytes']>;
+  sender_not?: InputMaybe<Scalars['Bytes']>;
+  sender_gt?: InputMaybe<Scalars['Bytes']>;
+  sender_lt?: InputMaybe<Scalars['Bytes']>;
+  sender_gte?: InputMaybe<Scalars['Bytes']>;
+  sender_lte?: InputMaybe<Scalars['Bytes']>;
+  sender_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  sender_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  sender_contains?: InputMaybe<Scalars['Bytes']>;
+  sender_not_contains?: InputMaybe<Scalars['Bytes']>;
+  recipient?: InputMaybe<Scalars['Bytes']>;
+  recipient_not?: InputMaybe<Scalars['Bytes']>;
+  recipient_gt?: InputMaybe<Scalars['Bytes']>;
+  recipient_lt?: InputMaybe<Scalars['Bytes']>;
+  recipient_gte?: InputMaybe<Scalars['Bytes']>;
+  recipient_lte?: InputMaybe<Scalars['Bytes']>;
+  recipient_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  recipient_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  recipient_contains?: InputMaybe<Scalars['Bytes']>;
+  recipient_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  wrappingFee?: InputMaybe<Scalars['BigInt']>;
+  wrappingFee_not?: InputMaybe<Scalars['BigInt']>;
+  wrappingFee_gt?: InputMaybe<Scalars['BigInt']>;
+  wrappingFee_lt?: InputMaybe<Scalars['BigInt']>;
+  wrappingFee_gte?: InputMaybe<Scalars['BigInt']>;
+  wrappingFee_lte?: InputMaybe<Scalars['BigInt']>;
+  wrappingFee_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  wrappingFee_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  afterFeeAmount?: InputMaybe<Scalars['BigInt']>;
+  afterFeeAmount_not?: InputMaybe<Scalars['BigInt']>;
+  afterFeeAmount_gt?: InputMaybe<Scalars['BigInt']>;
+  afterFeeAmount_lt?: InputMaybe<Scalars['BigInt']>;
+  afterFeeAmount_gte?: InputMaybe<Scalars['BigInt']>;
+  afterFeeAmount_lte?: InputMaybe<Scalars['BigInt']>;
+  afterFeeAmount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  afterFeeAmount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<WrappingEventLog_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<WrappingEventLog_filter>>>;
+};
+
+export type WrappingEventLog_orderBy =
+  | 'id'
+  | 'sender'
+  | 'recipient'
+  | 'tokenAddress'
+  | 'wrappingFee'
+  | 'afterFeeAmount'
+  | 'timestamp';
+
+export type _Block_ = {
+  /** The hash of the block */
+  hash?: Maybe<Scalars['Bytes']>;
+  /** The block number */
+  number: Scalars['Int'];
+  /** Integer representation of the timestamp stored in blocks for the chain */
+  timestamp?: Maybe<Scalars['Int']>;
+};
+
+/** The type for the top-level _meta field */
+export type _Meta_ = {
+  /**
+   * Information about a specific subgraph block. The hash of the block
+   * will be null if the _meta field has a block constraint that asks for
+   * a block number. It will be filled if the _meta field has no block constraint
+   * and therefore asks for the latest  block
+   *
+   */
+  block: _Block_;
+  /** The deployment ID */
+  deployment: Scalars['String'];
+  /** If `true`, the subgraph encountered indexing errors at some past block */
+  hasIndexingErrors: Scalars['Boolean'];
+};
+
+export type _SubgraphErrorPolicy_ =
+  /** Data will be returned even if the subgraph has indexing errors */
+  | 'allow'
+  /** If the subgraph has indexing errors, data will be omitted. The default. */
+  | 'deny';
+
+export type WithIndex<TObject> = TObject & Record<string, any>;
+export type ResolversObject<TObject> = WithIndex<TObject>;
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+
+export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  fragment: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+
+export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  selectionSet: string | ((fieldNode: FieldNode) => SelectionSetNode);
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | ResolverWithResolve<TResult, TParent, TContext, TArgs>
+  | StitchingResolver<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = ResolversObject<{
+  Query: ResolverTypeWrapper<{}>;
+  Subscription: ResolverTypeWrapper<{}>;
+  BigDecimal: ResolverTypeWrapper<Scalars['BigDecimal']>;
+  BigInt: ResolverTypeWrapper<Scalars['BigInt']>;
+  BlockChangedFilter: BlockChangedFilter;
+  Block_height: Block_height;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+  Bytes: ResolverTypeWrapper<Scalars['Bytes']>;
+  EdgeAddition: ResolverTypeWrapper<EdgeAddition>;
+  EdgeAddition_filter: EdgeAddition_filter;
+  EdgeAddition_orderBy: EdgeAddition_orderBy;
+  EdgeUpdate: ResolverTypeWrapper<EdgeUpdate>;
+  EdgeUpdate_filter: EdgeUpdate_filter;
+  EdgeUpdate_orderBy: EdgeUpdate_orderBy;
+  Encryptions: ResolverTypeWrapper<Encryptions>;
+  Encryptions_filter: Encryptions_filter;
+  Encryptions_orderBy: Encryptions_orderBy;
+  ExternalData: ResolverTypeWrapper<ExternalData>;
+  ExternalData_filter: ExternalData_filter;
+  ExternalData_orderBy: ExternalData_orderBy;
+  Float: ResolverTypeWrapper<Scalars['Float']>;
+  ID: ResolverTypeWrapper<Scalars['ID']>;
+  Insertion: ResolverTypeWrapper<Insertion>;
+  Insertion_filter: Insertion_filter;
+  Insertion_orderBy: Insertion_orderBy;
+  Int: ResolverTypeWrapper<Scalars['Int']>;
+  NewCommitment: ResolverTypeWrapper<NewCommitment>;
+  NewCommitment_filter: NewCommitment_filter;
+  NewCommitment_orderBy: NewCommitment_orderBy;
+  NewNullifier: ResolverTypeWrapper<NewNullifier>;
+  NewNullifier_filter: NewNullifier_filter;
+  NewNullifier_orderBy: NewNullifier_orderBy;
+  OrderDirection: OrderDirection;
+  PublicInputs: ResolverTypeWrapper<PublicInputs>;
+  PublicInputs_filter: PublicInputs_filter;
+  PublicInputs_orderBy: PublicInputs_orderBy;
+  PublicKey: ResolverTypeWrapper<PublicKey>;
+  PublicKey_filter: PublicKey_filter;
+  PublicKey_orderBy: PublicKey_orderBy;
+  ShieldedTransaction: ResolverTypeWrapper<ShieldedTransaction>;
+  ShieldedTransaction_filter: ShieldedTransaction_filter;
+  ShieldedTransaction_orderBy: ShieldedTransaction_orderBy;
+  String: ResolverTypeWrapper<Scalars['String']>;
+  Token: ResolverTypeWrapper<Token>;
+  Token_filter: Token_filter;
+  Token_orderBy: Token_orderBy;
+  UnwrappingEventLog: ResolverTypeWrapper<UnwrappingEventLog>;
+  UnwrappingEventLog_filter: UnwrappingEventLog_filter;
+  UnwrappingEventLog_orderBy: UnwrappingEventLog_orderBy;
+  VAnchorDeposit: ResolverTypeWrapper<VAnchorDeposit>;
+  VAnchorDepositByToken: ResolverTypeWrapper<VAnchorDepositByToken>;
+  VAnchorDepositByTokenEvery15Min: ResolverTypeWrapper<VAnchorDepositByTokenEvery15Min>;
+  VAnchorDepositByTokenEvery15Min_filter: VAnchorDepositByTokenEvery15Min_filter;
+  VAnchorDepositByTokenEvery15Min_orderBy: VAnchorDepositByTokenEvery15Min_orderBy;
+  VAnchorDepositByToken_filter: VAnchorDepositByToken_filter;
+  VAnchorDepositByToken_orderBy: VAnchorDepositByToken_orderBy;
+  VAnchorDepositEvery15Min: ResolverTypeWrapper<VAnchorDepositEvery15Min>;
+  VAnchorDepositEvery15Min_filter: VAnchorDepositEvery15Min_filter;
+  VAnchorDepositEvery15Min_orderBy: VAnchorDepositEvery15Min_orderBy;
+  VAnchorDepositLog: ResolverTypeWrapper<VAnchorDepositLog>;
+  VAnchorDepositLog_filter: VAnchorDepositLog_filter;
+  VAnchorDepositLog_orderBy: VAnchorDepositLog_orderBy;
+  VAnchorDeposit_filter: VAnchorDeposit_filter;
+  VAnchorDeposit_orderBy: VAnchorDeposit_orderBy;
+  VAnchorTotalRelayerFee: ResolverTypeWrapper<VAnchorTotalRelayerFee>;
+  VAnchorTotalRelayerFee15Min: ResolverTypeWrapper<VAnchorTotalRelayerFee15Min>;
+  VAnchorTotalRelayerFee15Min_filter: VAnchorTotalRelayerFee15Min_filter;
+  VAnchorTotalRelayerFee15Min_orderBy: VAnchorTotalRelayerFee15Min_orderBy;
+  VAnchorTotalRelayerFeeByToken: ResolverTypeWrapper<VAnchorTotalRelayerFeeByToken>;
+  VAnchorTotalRelayerFeeByTokenEvery15Min: ResolverTypeWrapper<VAnchorTotalRelayerFeeByTokenEvery15Min>;
+  VAnchorTotalRelayerFeeByTokenEvery15Min_filter: VAnchorTotalRelayerFeeByTokenEvery15Min_filter;
+  VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy: VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy;
+  VAnchorTotalRelayerFeeByToken_filter: VAnchorTotalRelayerFeeByToken_filter;
+  VAnchorTotalRelayerFeeByToken_orderBy: VAnchorTotalRelayerFeeByToken_orderBy;
+  VAnchorTotalRelayerFee_filter: VAnchorTotalRelayerFee_filter;
+  VAnchorTotalRelayerFee_orderBy: VAnchorTotalRelayerFee_orderBy;
+  VAnchorTotalValueLocked: ResolverTypeWrapper<VAnchorTotalValueLocked>;
+  VAnchorTotalValueLockedByToken: ResolverTypeWrapper<VAnchorTotalValueLockedByToken>;
+  VAnchorTotalValueLockedByTokenEvery15Min: ResolverTypeWrapper<VAnchorTotalValueLockedByTokenEvery15Min>;
+  VAnchorTotalValueLockedByTokenEvery15Min_filter: VAnchorTotalValueLockedByTokenEvery15Min_filter;
+  VAnchorTotalValueLockedByTokenEvery15Min_orderBy: VAnchorTotalValueLockedByTokenEvery15Min_orderBy;
+  VAnchorTotalValueLockedByToken_filter: VAnchorTotalValueLockedByToken_filter;
+  VAnchorTotalValueLockedByToken_orderBy: VAnchorTotalValueLockedByToken_orderBy;
+  VAnchorTotalValueLockedEvery15Min: ResolverTypeWrapper<VAnchorTotalValueLockedEvery15Min>;
+  VAnchorTotalValueLockedEvery15Min_filter: VAnchorTotalValueLockedEvery15Min_filter;
+  VAnchorTotalValueLockedEvery15Min_orderBy: VAnchorTotalValueLockedEvery15Min_orderBy;
+  VAnchorTotalValueLocked_filter: VAnchorTotalValueLocked_filter;
+  VAnchorTotalValueLocked_orderBy: VAnchorTotalValueLocked_orderBy;
+  VAnchorTotalWrappingFee: ResolverTypeWrapper<VAnchorTotalWrappingFee>;
+  VAnchorTotalWrappingFee15Min: ResolverTypeWrapper<VAnchorTotalWrappingFee15Min>;
+  VAnchorTotalWrappingFee15Min_filter: VAnchorTotalWrappingFee15Min_filter;
+  VAnchorTotalWrappingFee15Min_orderBy: VAnchorTotalWrappingFee15Min_orderBy;
+  VAnchorTotalWrappingFeeByToken: ResolverTypeWrapper<VAnchorTotalWrappingFeeByToken>;
+  VAnchorTotalWrappingFeeByTokenEvery15Min: ResolverTypeWrapper<VAnchorTotalWrappingFeeByTokenEvery15Min>;
+  VAnchorTotalWrappingFeeByTokenEvery15Min_filter: VAnchorTotalWrappingFeeByTokenEvery15Min_filter;
+  VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy: VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy;
+  VAnchorTotalWrappingFeeByToken_filter: VAnchorTotalWrappingFeeByToken_filter;
+  VAnchorTotalWrappingFeeByToken_orderBy: VAnchorTotalWrappingFeeByToken_orderBy;
+  VAnchorTotalWrappingFee_filter: VAnchorTotalWrappingFee_filter;
+  VAnchorTotalWrappingFee_orderBy: VAnchorTotalWrappingFee_orderBy;
+  VAnchorTransferLog: ResolverTypeWrapper<VAnchorTransferLog>;
+  VAnchorTransferLog_filter: VAnchorTransferLog_filter;
+  VAnchorTransferLog_orderBy: VAnchorTransferLog_orderBy;
+  VAnchorWithdrawal: ResolverTypeWrapper<VAnchorWithdrawal>;
+  VAnchorWithdrawalByToken: ResolverTypeWrapper<VAnchorWithdrawalByToken>;
+  VAnchorWithdrawalByTokenEvery15Min: ResolverTypeWrapper<VAnchorWithdrawalByTokenEvery15Min>;
+  VAnchorWithdrawalByTokenEvery15Min_filter: VAnchorWithdrawalByTokenEvery15Min_filter;
+  VAnchorWithdrawalByTokenEvery15Min_orderBy: VAnchorWithdrawalByTokenEvery15Min_orderBy;
+  VAnchorWithdrawalByToken_filter: VAnchorWithdrawalByToken_filter;
+  VAnchorWithdrawalByToken_orderBy: VAnchorWithdrawalByToken_orderBy;
+  VAnchorWithdrawalEvery15Min: ResolverTypeWrapper<VAnchorWithdrawalEvery15Min>;
+  VAnchorWithdrawalEvery15Min_filter: VAnchorWithdrawalEvery15Min_filter;
+  VAnchorWithdrawalEvery15Min_orderBy: VAnchorWithdrawalEvery15Min_orderBy;
+  VAnchorWithdrawalLog: ResolverTypeWrapper<VAnchorWithdrawalLog>;
+  VAnchorWithdrawalLog_filter: VAnchorWithdrawalLog_filter;
+  VAnchorWithdrawalLog_orderBy: VAnchorWithdrawalLog_orderBy;
+  VAnchorWithdrawal_filter: VAnchorWithdrawal_filter;
+  VAnchorWithdrawal_orderBy: VAnchorWithdrawal_orderBy;
+  WrappingEventLog: ResolverTypeWrapper<WrappingEventLog>;
+  WrappingEventLog_filter: WrappingEventLog_filter;
+  WrappingEventLog_orderBy: WrappingEventLog_orderBy;
+  _Block_: ResolverTypeWrapper<_Block_>;
+  _Meta_: ResolverTypeWrapper<_Meta_>;
+  _SubgraphErrorPolicy_: _SubgraphErrorPolicy_;
+}>;
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = ResolversObject<{
+  Query: {};
+  Subscription: {};
+  BigDecimal: Scalars['BigDecimal'];
+  BigInt: Scalars['BigInt'];
+  BlockChangedFilter: BlockChangedFilter;
+  Block_height: Block_height;
+  Boolean: Scalars['Boolean'];
+  Bytes: Scalars['Bytes'];
+  EdgeAddition: EdgeAddition;
+  EdgeAddition_filter: EdgeAddition_filter;
+  EdgeUpdate: EdgeUpdate;
+  EdgeUpdate_filter: EdgeUpdate_filter;
+  Encryptions: Encryptions;
+  Encryptions_filter: Encryptions_filter;
+  ExternalData: ExternalData;
+  ExternalData_filter: ExternalData_filter;
+  Float: Scalars['Float'];
+  ID: Scalars['ID'];
+  Insertion: Insertion;
+  Insertion_filter: Insertion_filter;
+  Int: Scalars['Int'];
+  NewCommitment: NewCommitment;
+  NewCommitment_filter: NewCommitment_filter;
+  NewNullifier: NewNullifier;
+  NewNullifier_filter: NewNullifier_filter;
+  PublicInputs: PublicInputs;
+  PublicInputs_filter: PublicInputs_filter;
+  PublicKey: PublicKey;
+  PublicKey_filter: PublicKey_filter;
+  ShieldedTransaction: ShieldedTransaction;
+  ShieldedTransaction_filter: ShieldedTransaction_filter;
+  String: Scalars['String'];
+  Token: Token;
+  Token_filter: Token_filter;
+  UnwrappingEventLog: UnwrappingEventLog;
+  UnwrappingEventLog_filter: UnwrappingEventLog_filter;
+  VAnchorDeposit: VAnchorDeposit;
+  VAnchorDepositByToken: VAnchorDepositByToken;
+  VAnchorDepositByTokenEvery15Min: VAnchorDepositByTokenEvery15Min;
+  VAnchorDepositByTokenEvery15Min_filter: VAnchorDepositByTokenEvery15Min_filter;
+  VAnchorDepositByToken_filter: VAnchorDepositByToken_filter;
+  VAnchorDepositEvery15Min: VAnchorDepositEvery15Min;
+  VAnchorDepositEvery15Min_filter: VAnchorDepositEvery15Min_filter;
+  VAnchorDepositLog: VAnchorDepositLog;
+  VAnchorDepositLog_filter: VAnchorDepositLog_filter;
+  VAnchorDeposit_filter: VAnchorDeposit_filter;
+  VAnchorTotalRelayerFee: VAnchorTotalRelayerFee;
+  VAnchorTotalRelayerFee15Min: VAnchorTotalRelayerFee15Min;
+  VAnchorTotalRelayerFee15Min_filter: VAnchorTotalRelayerFee15Min_filter;
+  VAnchorTotalRelayerFeeByToken: VAnchorTotalRelayerFeeByToken;
+  VAnchorTotalRelayerFeeByTokenEvery15Min: VAnchorTotalRelayerFeeByTokenEvery15Min;
+  VAnchorTotalRelayerFeeByTokenEvery15Min_filter: VAnchorTotalRelayerFeeByTokenEvery15Min_filter;
+  VAnchorTotalRelayerFeeByToken_filter: VAnchorTotalRelayerFeeByToken_filter;
+  VAnchorTotalRelayerFee_filter: VAnchorTotalRelayerFee_filter;
+  VAnchorTotalValueLocked: VAnchorTotalValueLocked;
+  VAnchorTotalValueLockedByToken: VAnchorTotalValueLockedByToken;
+  VAnchorTotalValueLockedByTokenEvery15Min: VAnchorTotalValueLockedByTokenEvery15Min;
+  VAnchorTotalValueLockedByTokenEvery15Min_filter: VAnchorTotalValueLockedByTokenEvery15Min_filter;
+  VAnchorTotalValueLockedByToken_filter: VAnchorTotalValueLockedByToken_filter;
+  VAnchorTotalValueLockedEvery15Min: VAnchorTotalValueLockedEvery15Min;
+  VAnchorTotalValueLockedEvery15Min_filter: VAnchorTotalValueLockedEvery15Min_filter;
+  VAnchorTotalValueLocked_filter: VAnchorTotalValueLocked_filter;
+  VAnchorTotalWrappingFee: VAnchorTotalWrappingFee;
+  VAnchorTotalWrappingFee15Min: VAnchorTotalWrappingFee15Min;
+  VAnchorTotalWrappingFee15Min_filter: VAnchorTotalWrappingFee15Min_filter;
+  VAnchorTotalWrappingFeeByToken: VAnchorTotalWrappingFeeByToken;
+  VAnchorTotalWrappingFeeByTokenEvery15Min: VAnchorTotalWrappingFeeByTokenEvery15Min;
+  VAnchorTotalWrappingFeeByTokenEvery15Min_filter: VAnchorTotalWrappingFeeByTokenEvery15Min_filter;
+  VAnchorTotalWrappingFeeByToken_filter: VAnchorTotalWrappingFeeByToken_filter;
+  VAnchorTotalWrappingFee_filter: VAnchorTotalWrappingFee_filter;
+  VAnchorTransferLog: VAnchorTransferLog;
+  VAnchorTransferLog_filter: VAnchorTransferLog_filter;
+  VAnchorWithdrawal: VAnchorWithdrawal;
+  VAnchorWithdrawalByToken: VAnchorWithdrawalByToken;
+  VAnchorWithdrawalByTokenEvery15Min: VAnchorWithdrawalByTokenEvery15Min;
+  VAnchorWithdrawalByTokenEvery15Min_filter: VAnchorWithdrawalByTokenEvery15Min_filter;
+  VAnchorWithdrawalByToken_filter: VAnchorWithdrawalByToken_filter;
+  VAnchorWithdrawalEvery15Min: VAnchorWithdrawalEvery15Min;
+  VAnchorWithdrawalEvery15Min_filter: VAnchorWithdrawalEvery15Min_filter;
+  VAnchorWithdrawalLog: VAnchorWithdrawalLog;
+  VAnchorWithdrawalLog_filter: VAnchorWithdrawalLog_filter;
+  VAnchorWithdrawal_filter: VAnchorWithdrawal_filter;
+  WrappingEventLog: WrappingEventLog;
+  WrappingEventLog_filter: WrappingEventLog_filter;
+  _Block_: _Block_;
+  _Meta_: _Meta_;
+}>;
+
+export type entityDirectiveArgs = { };
+
+export type entityDirectiveResolver<Result, Parent, ContextType = MeshContext & { subgraphUrl: string }, Args = entityDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
+export type subgraphIdDirectiveArgs = {
+  id: Scalars['String'];
+};
+
+export type subgraphIdDirectiveResolver<Result, Parent, ContextType = MeshContext & { subgraphUrl: string }, Args = subgraphIdDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
+export type derivedFromDirectiveArgs = {
+  field: Scalars['String'];
+};
+
+export type derivedFromDirectiveResolver<Result, Parent, ContextType = MeshContext & { subgraphUrl: string }, Args = derivedFromDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
+export type QueryResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
+  edgeAddition?: Resolver<Maybe<ResolversTypes['EdgeAddition']>, ParentType, ContextType, RequireFields<QueryedgeAdditionArgs, 'id' | 'subgraphError'>>;
+  edgeAdditions?: Resolver<Array<ResolversTypes['EdgeAddition']>, ParentType, ContextType, RequireFields<QueryedgeAdditionsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  edgeUpdate?: Resolver<Maybe<ResolversTypes['EdgeUpdate']>, ParentType, ContextType, RequireFields<QueryedgeUpdateArgs, 'id' | 'subgraphError'>>;
+  edgeUpdates?: Resolver<Array<ResolversTypes['EdgeUpdate']>, ParentType, ContextType, RequireFields<QueryedgeUpdatesArgs, 'skip' | 'first' | 'subgraphError'>>;
+  insertion?: Resolver<Maybe<ResolversTypes['Insertion']>, ParentType, ContextType, RequireFields<QueryinsertionArgs, 'id' | 'subgraphError'>>;
+  insertions?: Resolver<Array<ResolversTypes['Insertion']>, ParentType, ContextType, RequireFields<QueryinsertionsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  newCommitment?: Resolver<Maybe<ResolversTypes['NewCommitment']>, ParentType, ContextType, RequireFields<QuerynewCommitmentArgs, 'id' | 'subgraphError'>>;
+  newCommitments?: Resolver<Array<ResolversTypes['NewCommitment']>, ParentType, ContextType, RequireFields<QuerynewCommitmentsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  newNullifier?: Resolver<Maybe<ResolversTypes['NewNullifier']>, ParentType, ContextType, RequireFields<QuerynewNullifierArgs, 'id' | 'subgraphError'>>;
+  newNullifiers?: Resolver<Array<ResolversTypes['NewNullifier']>, ParentType, ContextType, RequireFields<QuerynewNullifiersArgs, 'skip' | 'first' | 'subgraphError'>>;
+  publicKey?: Resolver<Maybe<ResolversTypes['PublicKey']>, ParentType, ContextType, RequireFields<QuerypublicKeyArgs, 'id' | 'subgraphError'>>;
+  publicKeys?: Resolver<Array<ResolversTypes['PublicKey']>, ParentType, ContextType, RequireFields<QuerypublicKeysArgs, 'skip' | 'first' | 'subgraphError'>>;
+  token?: Resolver<Maybe<ResolversTypes['Token']>, ParentType, ContextType, RequireFields<QuerytokenArgs, 'id' | 'subgraphError'>>;
+  tokens?: Resolver<Array<ResolversTypes['Token']>, ParentType, ContextType, RequireFields<QuerytokensArgs, 'skip' | 'first' | 'subgraphError'>>;
+  externalData?: Resolver<Maybe<ResolversTypes['ExternalData']>, ParentType, ContextType, RequireFields<QueryexternalDataArgs, 'id' | 'subgraphError'>>;
+  externalDatas?: Resolver<Array<ResolversTypes['ExternalData']>, ParentType, ContextType, RequireFields<QueryexternalDatasArgs, 'skip' | 'first' | 'subgraphError'>>;
+  publicInputs?: Resolver<Array<ResolversTypes['PublicInputs']>, ParentType, ContextType, RequireFields<QuerypublicInputsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  encryptions?: Resolver<Array<ResolversTypes['Encryptions']>, ParentType, ContextType, RequireFields<QueryencryptionsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  shieldedTransaction?: Resolver<Maybe<ResolversTypes['ShieldedTransaction']>, ParentType, ContextType, RequireFields<QueryshieldedTransactionArgs, 'id' | 'subgraphError'>>;
+  shieldedTransactions?: Resolver<Array<ResolversTypes['ShieldedTransaction']>, ParentType, ContextType, RequireFields<QueryshieldedTransactionsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalValueLocked?: Resolver<Maybe<ResolversTypes['VAnchorTotalValueLocked']>, ParentType, ContextType, RequireFields<QueryvanchorTotalValueLockedArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalValueLockeds?: Resolver<Array<ResolversTypes['VAnchorTotalValueLocked']>, ParentType, ContextType, RequireFields<QueryvanchorTotalValueLockedsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalValueLockedByToken?: Resolver<Maybe<ResolversTypes['VAnchorTotalValueLockedByToken']>, ParentType, ContextType, RequireFields<QueryvanchorTotalValueLockedByTokenArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalValueLockedByTokens?: Resolver<Array<ResolversTypes['VAnchorTotalValueLockedByToken']>, ParentType, ContextType, RequireFields<QueryvanchorTotalValueLockedByTokensArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalValueLockedEvery15Min?: Resolver<Maybe<ResolversTypes['VAnchorTotalValueLockedEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorTotalValueLockedEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalValueLockedEvery15Mins?: Resolver<Array<ResolversTypes['VAnchorTotalValueLockedEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorTotalValueLockedEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalValueLockedByTokenEvery15Min?: Resolver<Maybe<ResolversTypes['VAnchorTotalValueLockedByTokenEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorTotalValueLockedByTokenEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalValueLockedByTokenEvery15Mins?: Resolver<Array<ResolversTypes['VAnchorTotalValueLockedByTokenEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorTotalValueLockedByTokenEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalRelayerFee?: Resolver<Maybe<ResolversTypes['VAnchorTotalRelayerFee']>, ParentType, ContextType, RequireFields<QueryvanchorTotalRelayerFeeArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalRelayerFees?: Resolver<Array<ResolversTypes['VAnchorTotalRelayerFee']>, ParentType, ContextType, RequireFields<QueryvanchorTotalRelayerFeesArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalRelayerFeeByToken?: Resolver<Maybe<ResolversTypes['VAnchorTotalRelayerFeeByToken']>, ParentType, ContextType, RequireFields<QueryvanchorTotalRelayerFeeByTokenArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalRelayerFeeByTokens?: Resolver<Array<ResolversTypes['VAnchorTotalRelayerFeeByToken']>, ParentType, ContextType, RequireFields<QueryvanchorTotalRelayerFeeByTokensArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalRelayerFee15Min?: Resolver<Maybe<ResolversTypes['VAnchorTotalRelayerFee15Min']>, ParentType, ContextType, RequireFields<QueryvanchorTotalRelayerFee15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalRelayerFee15Mins?: Resolver<Array<ResolversTypes['VAnchorTotalRelayerFee15Min']>, ParentType, ContextType, RequireFields<QueryvanchorTotalRelayerFee15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalRelayerFeeByTokenEvery15Min?: Resolver<Maybe<ResolversTypes['VAnchorTotalRelayerFeeByTokenEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorTotalRelayerFeeByTokenEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalRelayerFeeByTokenEvery15Mins?: Resolver<Array<ResolversTypes['VAnchorTotalRelayerFeeByTokenEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorTotalRelayerFeeByTokenEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalWrappingFee?: Resolver<Maybe<ResolversTypes['VAnchorTotalWrappingFee']>, ParentType, ContextType, RequireFields<QueryvanchorTotalWrappingFeeArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalWrappingFees?: Resolver<Array<ResolversTypes['VAnchorTotalWrappingFee']>, ParentType, ContextType, RequireFields<QueryvanchorTotalWrappingFeesArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalWrappingFeeByToken?: Resolver<Maybe<ResolversTypes['VAnchorTotalWrappingFeeByToken']>, ParentType, ContextType, RequireFields<QueryvanchorTotalWrappingFeeByTokenArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalWrappingFeeByTokens?: Resolver<Array<ResolversTypes['VAnchorTotalWrappingFeeByToken']>, ParentType, ContextType, RequireFields<QueryvanchorTotalWrappingFeeByTokensArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalWrappingFee15Min?: Resolver<Maybe<ResolversTypes['VAnchorTotalWrappingFee15Min']>, ParentType, ContextType, RequireFields<QueryvanchorTotalWrappingFee15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalWrappingFee15Mins?: Resolver<Array<ResolversTypes['VAnchorTotalWrappingFee15Min']>, ParentType, ContextType, RequireFields<QueryvanchorTotalWrappingFee15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalWrappingFeeByTokenEvery15Min?: Resolver<Maybe<ResolversTypes['VAnchorTotalWrappingFeeByTokenEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorTotalWrappingFeeByTokenEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalWrappingFeeByTokenEvery15Mins?: Resolver<Array<ResolversTypes['VAnchorTotalWrappingFeeByTokenEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorTotalWrappingFeeByTokenEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  wrappingEventLog?: Resolver<Maybe<ResolversTypes['WrappingEventLog']>, ParentType, ContextType, RequireFields<QuerywrappingEventLogArgs, 'id' | 'subgraphError'>>;
+  wrappingEventLogs?: Resolver<Array<ResolversTypes['WrappingEventLog']>, ParentType, ContextType, RequireFields<QuerywrappingEventLogsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  unwrappingEventLog?: Resolver<Maybe<ResolversTypes['UnwrappingEventLog']>, ParentType, ContextType, RequireFields<QueryunwrappingEventLogArgs, 'id' | 'subgraphError'>>;
+  unwrappingEventLogs?: Resolver<Array<ResolversTypes['UnwrappingEventLog']>, ParentType, ContextType, RequireFields<QueryunwrappingEventLogsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorWithdrawalLog?: Resolver<Maybe<ResolversTypes['VAnchorWithdrawalLog']>, ParentType, ContextType, RequireFields<QueryvanchorWithdrawalLogArgs, 'id' | 'subgraphError'>>;
+  vanchorWithdrawalLogs?: Resolver<Array<ResolversTypes['VAnchorWithdrawalLog']>, ParentType, ContextType, RequireFields<QueryvanchorWithdrawalLogsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorWithdrawal?: Resolver<Maybe<ResolversTypes['VAnchorWithdrawal']>, ParentType, ContextType, RequireFields<QueryvanchorWithdrawalArgs, 'id' | 'subgraphError'>>;
+  vanchorWithdrawals?: Resolver<Array<ResolversTypes['VAnchorWithdrawal']>, ParentType, ContextType, RequireFields<QueryvanchorWithdrawalsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorWithdrawalByToken?: Resolver<Maybe<ResolversTypes['VAnchorWithdrawalByToken']>, ParentType, ContextType, RequireFields<QueryvanchorWithdrawalByTokenArgs, 'id' | 'subgraphError'>>;
+  vanchorWithdrawalByTokens?: Resolver<Array<ResolversTypes['VAnchorWithdrawalByToken']>, ParentType, ContextType, RequireFields<QueryvanchorWithdrawalByTokensArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorWithdrawalEvery15Min?: Resolver<Maybe<ResolversTypes['VAnchorWithdrawalEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorWithdrawalEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorWithdrawalEvery15Mins?: Resolver<Array<ResolversTypes['VAnchorWithdrawalEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorWithdrawalEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorWithdrawalByTokenEvery15Min?: Resolver<Maybe<ResolversTypes['VAnchorWithdrawalByTokenEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorWithdrawalByTokenEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorWithdrawalByTokenEvery15Mins?: Resolver<Array<ResolversTypes['VAnchorWithdrawalByTokenEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorWithdrawalByTokenEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorDeposit?: Resolver<Maybe<ResolversTypes['VAnchorDeposit']>, ParentType, ContextType, RequireFields<QueryvanchorDepositArgs, 'id' | 'subgraphError'>>;
+  vanchorDeposits?: Resolver<Array<ResolversTypes['VAnchorDeposit']>, ParentType, ContextType, RequireFields<QueryvanchorDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorDepositByToken?: Resolver<Maybe<ResolversTypes['VAnchorDepositByToken']>, ParentType, ContextType, RequireFields<QueryvanchorDepositByTokenArgs, 'id' | 'subgraphError'>>;
+  vanchorDepositByTokens?: Resolver<Array<ResolversTypes['VAnchorDepositByToken']>, ParentType, ContextType, RequireFields<QueryvanchorDepositByTokensArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorDepositEvery15Min?: Resolver<Maybe<ResolversTypes['VAnchorDepositEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorDepositEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorDepositEvery15Mins?: Resolver<Array<ResolversTypes['VAnchorDepositEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorDepositEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorDepositByTokenEvery15Min?: Resolver<Maybe<ResolversTypes['VAnchorDepositByTokenEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorDepositByTokenEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorDepositByTokenEvery15Mins?: Resolver<Array<ResolversTypes['VAnchorDepositByTokenEvery15Min']>, ParentType, ContextType, RequireFields<QueryvanchorDepositByTokenEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorDepositLog?: Resolver<Maybe<ResolversTypes['VAnchorDepositLog']>, ParentType, ContextType, RequireFields<QueryvanchorDepositLogArgs, 'id' | 'subgraphError'>>;
+  vanchorDepositLogs?: Resolver<Array<ResolversTypes['VAnchorDepositLog']>, ParentType, ContextType, RequireFields<QueryvanchorDepositLogsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTransferLog?: Resolver<Maybe<ResolversTypes['VAnchorTransferLog']>, ParentType, ContextType, RequireFields<QueryvanchorTransferLogArgs, 'id' | 'subgraphError'>>;
+  vanchorTransferLogs?: Resolver<Array<ResolversTypes['VAnchorTransferLog']>, ParentType, ContextType, RequireFields<QueryvanchorTransferLogsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  _meta?: Resolver<Maybe<ResolversTypes['_Meta_']>, ParentType, ContextType, Partial<Query_metaArgs>>;
+}>;
+
+export type SubscriptionResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = ResolversObject<{
+  edgeAddition?: SubscriptionResolver<Maybe<ResolversTypes['EdgeAddition']>, "edgeAddition", ParentType, ContextType, RequireFields<SubscriptionedgeAdditionArgs, 'id' | 'subgraphError'>>;
+  edgeAdditions?: SubscriptionResolver<Array<ResolversTypes['EdgeAddition']>, "edgeAdditions", ParentType, ContextType, RequireFields<SubscriptionedgeAdditionsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  edgeUpdate?: SubscriptionResolver<Maybe<ResolversTypes['EdgeUpdate']>, "edgeUpdate", ParentType, ContextType, RequireFields<SubscriptionedgeUpdateArgs, 'id' | 'subgraphError'>>;
+  edgeUpdates?: SubscriptionResolver<Array<ResolversTypes['EdgeUpdate']>, "edgeUpdates", ParentType, ContextType, RequireFields<SubscriptionedgeUpdatesArgs, 'skip' | 'first' | 'subgraphError'>>;
+  insertion?: SubscriptionResolver<Maybe<ResolversTypes['Insertion']>, "insertion", ParentType, ContextType, RequireFields<SubscriptioninsertionArgs, 'id' | 'subgraphError'>>;
+  insertions?: SubscriptionResolver<Array<ResolversTypes['Insertion']>, "insertions", ParentType, ContextType, RequireFields<SubscriptioninsertionsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  newCommitment?: SubscriptionResolver<Maybe<ResolversTypes['NewCommitment']>, "newCommitment", ParentType, ContextType, RequireFields<SubscriptionnewCommitmentArgs, 'id' | 'subgraphError'>>;
+  newCommitments?: SubscriptionResolver<Array<ResolversTypes['NewCommitment']>, "newCommitments", ParentType, ContextType, RequireFields<SubscriptionnewCommitmentsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  newNullifier?: SubscriptionResolver<Maybe<ResolversTypes['NewNullifier']>, "newNullifier", ParentType, ContextType, RequireFields<SubscriptionnewNullifierArgs, 'id' | 'subgraphError'>>;
+  newNullifiers?: SubscriptionResolver<Array<ResolversTypes['NewNullifier']>, "newNullifiers", ParentType, ContextType, RequireFields<SubscriptionnewNullifiersArgs, 'skip' | 'first' | 'subgraphError'>>;
+  publicKey?: SubscriptionResolver<Maybe<ResolversTypes['PublicKey']>, "publicKey", ParentType, ContextType, RequireFields<SubscriptionpublicKeyArgs, 'id' | 'subgraphError'>>;
+  publicKeys?: SubscriptionResolver<Array<ResolversTypes['PublicKey']>, "publicKeys", ParentType, ContextType, RequireFields<SubscriptionpublicKeysArgs, 'skip' | 'first' | 'subgraphError'>>;
+  token?: SubscriptionResolver<Maybe<ResolversTypes['Token']>, "token", ParentType, ContextType, RequireFields<SubscriptiontokenArgs, 'id' | 'subgraphError'>>;
+  tokens?: SubscriptionResolver<Array<ResolversTypes['Token']>, "tokens", ParentType, ContextType, RequireFields<SubscriptiontokensArgs, 'skip' | 'first' | 'subgraphError'>>;
+  externalData?: SubscriptionResolver<Maybe<ResolversTypes['ExternalData']>, "externalData", ParentType, ContextType, RequireFields<SubscriptionexternalDataArgs, 'id' | 'subgraphError'>>;
+  externalDatas?: SubscriptionResolver<Array<ResolversTypes['ExternalData']>, "externalDatas", ParentType, ContextType, RequireFields<SubscriptionexternalDatasArgs, 'skip' | 'first' | 'subgraphError'>>;
+  publicInputs?: SubscriptionResolver<Array<ResolversTypes['PublicInputs']>, "publicInputs", ParentType, ContextType, RequireFields<SubscriptionpublicInputsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  encryptions?: SubscriptionResolver<Array<ResolversTypes['Encryptions']>, "encryptions", ParentType, ContextType, RequireFields<SubscriptionencryptionsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  shieldedTransaction?: SubscriptionResolver<Maybe<ResolversTypes['ShieldedTransaction']>, "shieldedTransaction", ParentType, ContextType, RequireFields<SubscriptionshieldedTransactionArgs, 'id' | 'subgraphError'>>;
+  shieldedTransactions?: SubscriptionResolver<Array<ResolversTypes['ShieldedTransaction']>, "shieldedTransactions", ParentType, ContextType, RequireFields<SubscriptionshieldedTransactionsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalValueLocked?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorTotalValueLocked']>, "vanchorTotalValueLocked", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalValueLockedArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalValueLockeds?: SubscriptionResolver<Array<ResolversTypes['VAnchorTotalValueLocked']>, "vanchorTotalValueLockeds", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalValueLockedsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalValueLockedByToken?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorTotalValueLockedByToken']>, "vanchorTotalValueLockedByToken", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalValueLockedByTokenArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalValueLockedByTokens?: SubscriptionResolver<Array<ResolversTypes['VAnchorTotalValueLockedByToken']>, "vanchorTotalValueLockedByTokens", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalValueLockedByTokensArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalValueLockedEvery15Min?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorTotalValueLockedEvery15Min']>, "vanchorTotalValueLockedEvery15Min", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalValueLockedEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalValueLockedEvery15Mins?: SubscriptionResolver<Array<ResolversTypes['VAnchorTotalValueLockedEvery15Min']>, "vanchorTotalValueLockedEvery15Mins", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalValueLockedEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalValueLockedByTokenEvery15Min?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorTotalValueLockedByTokenEvery15Min']>, "vanchorTotalValueLockedByTokenEvery15Min", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalValueLockedByTokenEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalValueLockedByTokenEvery15Mins?: SubscriptionResolver<Array<ResolversTypes['VAnchorTotalValueLockedByTokenEvery15Min']>, "vanchorTotalValueLockedByTokenEvery15Mins", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalValueLockedByTokenEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalRelayerFee?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorTotalRelayerFee']>, "vanchorTotalRelayerFee", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalRelayerFeeArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalRelayerFees?: SubscriptionResolver<Array<ResolversTypes['VAnchorTotalRelayerFee']>, "vanchorTotalRelayerFees", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalRelayerFeesArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalRelayerFeeByToken?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorTotalRelayerFeeByToken']>, "vanchorTotalRelayerFeeByToken", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalRelayerFeeByTokenArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalRelayerFeeByTokens?: SubscriptionResolver<Array<ResolversTypes['VAnchorTotalRelayerFeeByToken']>, "vanchorTotalRelayerFeeByTokens", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalRelayerFeeByTokensArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalRelayerFee15Min?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorTotalRelayerFee15Min']>, "vanchorTotalRelayerFee15Min", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalRelayerFee15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalRelayerFee15Mins?: SubscriptionResolver<Array<ResolversTypes['VAnchorTotalRelayerFee15Min']>, "vanchorTotalRelayerFee15Mins", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalRelayerFee15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalRelayerFeeByTokenEvery15Min?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorTotalRelayerFeeByTokenEvery15Min']>, "vanchorTotalRelayerFeeByTokenEvery15Min", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalRelayerFeeByTokenEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalRelayerFeeByTokenEvery15Mins?: SubscriptionResolver<Array<ResolversTypes['VAnchorTotalRelayerFeeByTokenEvery15Min']>, "vanchorTotalRelayerFeeByTokenEvery15Mins", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalRelayerFeeByTokenEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalWrappingFee?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorTotalWrappingFee']>, "vanchorTotalWrappingFee", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalWrappingFeeArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalWrappingFees?: SubscriptionResolver<Array<ResolversTypes['VAnchorTotalWrappingFee']>, "vanchorTotalWrappingFees", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalWrappingFeesArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalWrappingFeeByToken?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorTotalWrappingFeeByToken']>, "vanchorTotalWrappingFeeByToken", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalWrappingFeeByTokenArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalWrappingFeeByTokens?: SubscriptionResolver<Array<ResolversTypes['VAnchorTotalWrappingFeeByToken']>, "vanchorTotalWrappingFeeByTokens", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalWrappingFeeByTokensArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalWrappingFee15Min?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorTotalWrappingFee15Min']>, "vanchorTotalWrappingFee15Min", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalWrappingFee15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalWrappingFee15Mins?: SubscriptionResolver<Array<ResolversTypes['VAnchorTotalWrappingFee15Min']>, "vanchorTotalWrappingFee15Mins", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalWrappingFee15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTotalWrappingFeeByTokenEvery15Min?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorTotalWrappingFeeByTokenEvery15Min']>, "vanchorTotalWrappingFeeByTokenEvery15Min", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalWrappingFeeByTokenEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorTotalWrappingFeeByTokenEvery15Mins?: SubscriptionResolver<Array<ResolversTypes['VAnchorTotalWrappingFeeByTokenEvery15Min']>, "vanchorTotalWrappingFeeByTokenEvery15Mins", ParentType, ContextType, RequireFields<SubscriptionvanchorTotalWrappingFeeByTokenEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  wrappingEventLog?: SubscriptionResolver<Maybe<ResolversTypes['WrappingEventLog']>, "wrappingEventLog", ParentType, ContextType, RequireFields<SubscriptionwrappingEventLogArgs, 'id' | 'subgraphError'>>;
+  wrappingEventLogs?: SubscriptionResolver<Array<ResolversTypes['WrappingEventLog']>, "wrappingEventLogs", ParentType, ContextType, RequireFields<SubscriptionwrappingEventLogsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  unwrappingEventLog?: SubscriptionResolver<Maybe<ResolversTypes['UnwrappingEventLog']>, "unwrappingEventLog", ParentType, ContextType, RequireFields<SubscriptionunwrappingEventLogArgs, 'id' | 'subgraphError'>>;
+  unwrappingEventLogs?: SubscriptionResolver<Array<ResolversTypes['UnwrappingEventLog']>, "unwrappingEventLogs", ParentType, ContextType, RequireFields<SubscriptionunwrappingEventLogsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorWithdrawalLog?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorWithdrawalLog']>, "vanchorWithdrawalLog", ParentType, ContextType, RequireFields<SubscriptionvanchorWithdrawalLogArgs, 'id' | 'subgraphError'>>;
+  vanchorWithdrawalLogs?: SubscriptionResolver<Array<ResolversTypes['VAnchorWithdrawalLog']>, "vanchorWithdrawalLogs", ParentType, ContextType, RequireFields<SubscriptionvanchorWithdrawalLogsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorWithdrawal?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorWithdrawal']>, "vanchorWithdrawal", ParentType, ContextType, RequireFields<SubscriptionvanchorWithdrawalArgs, 'id' | 'subgraphError'>>;
+  vanchorWithdrawals?: SubscriptionResolver<Array<ResolversTypes['VAnchorWithdrawal']>, "vanchorWithdrawals", ParentType, ContextType, RequireFields<SubscriptionvanchorWithdrawalsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorWithdrawalByToken?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorWithdrawalByToken']>, "vanchorWithdrawalByToken", ParentType, ContextType, RequireFields<SubscriptionvanchorWithdrawalByTokenArgs, 'id' | 'subgraphError'>>;
+  vanchorWithdrawalByTokens?: SubscriptionResolver<Array<ResolversTypes['VAnchorWithdrawalByToken']>, "vanchorWithdrawalByTokens", ParentType, ContextType, RequireFields<SubscriptionvanchorWithdrawalByTokensArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorWithdrawalEvery15Min?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorWithdrawalEvery15Min']>, "vanchorWithdrawalEvery15Min", ParentType, ContextType, RequireFields<SubscriptionvanchorWithdrawalEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorWithdrawalEvery15Mins?: SubscriptionResolver<Array<ResolversTypes['VAnchorWithdrawalEvery15Min']>, "vanchorWithdrawalEvery15Mins", ParentType, ContextType, RequireFields<SubscriptionvanchorWithdrawalEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorWithdrawalByTokenEvery15Min?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorWithdrawalByTokenEvery15Min']>, "vanchorWithdrawalByTokenEvery15Min", ParentType, ContextType, RequireFields<SubscriptionvanchorWithdrawalByTokenEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorWithdrawalByTokenEvery15Mins?: SubscriptionResolver<Array<ResolversTypes['VAnchorWithdrawalByTokenEvery15Min']>, "vanchorWithdrawalByTokenEvery15Mins", ParentType, ContextType, RequireFields<SubscriptionvanchorWithdrawalByTokenEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorDeposit?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorDeposit']>, "vanchorDeposit", ParentType, ContextType, RequireFields<SubscriptionvanchorDepositArgs, 'id' | 'subgraphError'>>;
+  vanchorDeposits?: SubscriptionResolver<Array<ResolversTypes['VAnchorDeposit']>, "vanchorDeposits", ParentType, ContextType, RequireFields<SubscriptionvanchorDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorDepositByToken?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorDepositByToken']>, "vanchorDepositByToken", ParentType, ContextType, RequireFields<SubscriptionvanchorDepositByTokenArgs, 'id' | 'subgraphError'>>;
+  vanchorDepositByTokens?: SubscriptionResolver<Array<ResolversTypes['VAnchorDepositByToken']>, "vanchorDepositByTokens", ParentType, ContextType, RequireFields<SubscriptionvanchorDepositByTokensArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorDepositEvery15Min?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorDepositEvery15Min']>, "vanchorDepositEvery15Min", ParentType, ContextType, RequireFields<SubscriptionvanchorDepositEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorDepositEvery15Mins?: SubscriptionResolver<Array<ResolversTypes['VAnchorDepositEvery15Min']>, "vanchorDepositEvery15Mins", ParentType, ContextType, RequireFields<SubscriptionvanchorDepositEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorDepositByTokenEvery15Min?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorDepositByTokenEvery15Min']>, "vanchorDepositByTokenEvery15Min", ParentType, ContextType, RequireFields<SubscriptionvanchorDepositByTokenEvery15MinArgs, 'id' | 'subgraphError'>>;
+  vanchorDepositByTokenEvery15Mins?: SubscriptionResolver<Array<ResolversTypes['VAnchorDepositByTokenEvery15Min']>, "vanchorDepositByTokenEvery15Mins", ParentType, ContextType, RequireFields<SubscriptionvanchorDepositByTokenEvery15MinsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorDepositLog?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorDepositLog']>, "vanchorDepositLog", ParentType, ContextType, RequireFields<SubscriptionvanchorDepositLogArgs, 'id' | 'subgraphError'>>;
+  vanchorDepositLogs?: SubscriptionResolver<Array<ResolversTypes['VAnchorDepositLog']>, "vanchorDepositLogs", ParentType, ContextType, RequireFields<SubscriptionvanchorDepositLogsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  vanchorTransferLog?: SubscriptionResolver<Maybe<ResolversTypes['VAnchorTransferLog']>, "vanchorTransferLog", ParentType, ContextType, RequireFields<SubscriptionvanchorTransferLogArgs, 'id' | 'subgraphError'>>;
+  vanchorTransferLogs?: SubscriptionResolver<Array<ResolversTypes['VAnchorTransferLog']>, "vanchorTransferLogs", ParentType, ContextType, RequireFields<SubscriptionvanchorTransferLogsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  _meta?: SubscriptionResolver<Maybe<ResolversTypes['_Meta_']>, "_meta", ParentType, ContextType, Partial<Subscription_metaArgs>>;
+}>;
+
+export interface BigDecimalScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['BigDecimal'], any> {
+  name: 'BigDecimal';
+}
+
+export interface BigIntScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['BigInt'], any> {
+  name: 'BigInt';
+}
+
+export interface BytesScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Bytes'], any> {
+  name: 'Bytes';
+}
+
+export type EdgeAdditionResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['EdgeAddition'] = ResolversParentTypes['EdgeAddition']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  chainID?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  latestLeafIndex?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  merkleRoot?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  blockNumber?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  blockTimestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  transactionHash?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type EdgeUpdateResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['EdgeUpdate'] = ResolversParentTypes['EdgeUpdate']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  chainID?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  latestLeafIndex?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  merkleRoot?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  blockNumber?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  blockTimestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  transactionHash?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type EncryptionsResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['Encryptions'] = ResolversParentTypes['Encryptions']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  encryptedOutput1?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  encryptedOutput2?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type ExternalDataResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['ExternalData'] = ResolversParentTypes['ExternalData']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  recipient?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  extAmount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  relayer?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  fee?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  refund?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  token?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type InsertionResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['Insertion'] = ResolversParentTypes['Insertion']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  commitment?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  leafIndex?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  newMerkleRoot?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  blockNumber?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  blockTimestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  transactionHash?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type NewCommitmentResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['NewCommitment'] = ResolversParentTypes['NewCommitment']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  commitment?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  subTreeIndex?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  leafIndex?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  encryptedOutput?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  blockNumber?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  blockTimestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  transactionHash?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type NewNullifierResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['NewNullifier'] = ResolversParentTypes['NewNullifier']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  nullifier?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  blockNumber?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  blockTimestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  transactionHash?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type PublicInputsResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['PublicInputs'] = ResolversParentTypes['PublicInputs']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  roots?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  extensionRoots?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  inputNullifiers?: Resolver<Array<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  outputCommitments?: Resolver<Array<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  publicAmount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  extDataHash?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type PublicKeyResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['PublicKey'] = ResolversParentTypes['PublicKey']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  owner?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  key?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  blockNumber?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  blockTimestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  transactionHash?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type ShieldedTransactionResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['ShieldedTransaction'] = ResolversParentTypes['ShieldedTransaction']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  vanchor?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  sender?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  value?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  proof?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  auxPublicInputs?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  externalData?: Resolver<ResolversTypes['ExternalData'], ParentType, ContextType>;
+  publicInputs?: Resolver<ResolversTypes['PublicInputs'], ParentType, ContextType>;
+  encryptions?: Resolver<ResolversTypes['Encryptions'], ParentType, ContextType>;
+  blockNumber?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  blockTimestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  transactionHash?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  subgraphUrl?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type TokenResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['Token'] = ResolversParentTypes['Token']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  address?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  decimals?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  symbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type UnwrappingEventLogResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['UnwrappingEventLog'] = ResolversParentTypes['UnwrappingEventLog']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  sender?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  recipient?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  amount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorDepositResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorDeposit'] = ResolversParentTypes['VAnchorDeposit']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  deposit?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  averageDeposit?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  totalCount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorDepositByTokenResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorDepositByToken'] = ResolversParentTypes['VAnchorDepositByToken']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenSymbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  deposit?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  averageDeposit?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  totalCount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorDepositByTokenEvery15MinResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorDepositByTokenEvery15Min'] = ResolversParentTypes['VAnchorDepositByTokenEvery15Min']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenSymbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  startInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  endInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  deposit?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  averageDeposit?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  totalCount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorDepositEvery15MinResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorDepositEvery15Min'] = ResolversParentTypes['VAnchorDepositEvery15Min']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  startInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  endInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  deposit?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  averageDeposit?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  totalCount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorDepositLogResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorDepositLog'] = ResolversParentTypes['VAnchorDepositLog']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  deposit?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenSymbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorTotalRelayerFeeResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorTotalRelayerFee'] = ResolversParentTypes['VAnchorTotalRelayerFee']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  fees?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorTotalRelayerFee15MinResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorTotalRelayerFee15Min'] = ResolversParentTypes['VAnchorTotalRelayerFee15Min']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  startInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  endInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  fees?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorTotalRelayerFeeByTokenResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorTotalRelayerFeeByToken'] = ResolversParentTypes['VAnchorTotalRelayerFeeByToken']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenSymbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  fees?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorTotalRelayerFeeByTokenEvery15MinResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorTotalRelayerFeeByTokenEvery15Min'] = ResolversParentTypes['VAnchorTotalRelayerFeeByTokenEvery15Min']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenSymbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  startInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  endInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  fees?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorTotalValueLockedResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorTotalValueLocked'] = ResolversParentTypes['VAnchorTotalValueLocked']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  totalValueLocked?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorTotalValueLockedByTokenResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorTotalValueLockedByToken'] = ResolversParentTypes['VAnchorTotalValueLockedByToken']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenSymbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  totalValueLocked?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorTotalValueLockedByTokenEvery15MinResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorTotalValueLockedByTokenEvery15Min'] = ResolversParentTypes['VAnchorTotalValueLockedByTokenEvery15Min']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenSymbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  startInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  endInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  totalValueLocked?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorTotalValueLockedEvery15MinResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorTotalValueLockedEvery15Min'] = ResolversParentTypes['VAnchorTotalValueLockedEvery15Min']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  startInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  endInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  totalValueLocked?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorTotalWrappingFeeResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorTotalWrappingFee'] = ResolversParentTypes['VAnchorTotalWrappingFee']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  fees?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorTotalWrappingFee15MinResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorTotalWrappingFee15Min'] = ResolversParentTypes['VAnchorTotalWrappingFee15Min']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  startInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  endInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  fees?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorTotalWrappingFeeByTokenResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorTotalWrappingFeeByToken'] = ResolversParentTypes['VAnchorTotalWrappingFeeByToken']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenSymbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  fees?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorTotalWrappingFeeByTokenEvery15MinResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorTotalWrappingFeeByTokenEvery15Min'] = ResolversParentTypes['VAnchorTotalWrappingFeeByTokenEvery15Min']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenSymbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  startInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  endInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  fees?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorTransferLogResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorTransferLog'] = ResolversParentTypes['VAnchorTransferLog']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenSymbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorWithdrawalResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorWithdrawal'] = ResolversParentTypes['VAnchorWithdrawal']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  withdrawal?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  averageWithdrawal?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  totalCount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorWithdrawalByTokenResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorWithdrawalByToken'] = ResolversParentTypes['VAnchorWithdrawalByToken']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenSymbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  withdrawal?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  averageWithdrawal?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  totalCount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorWithdrawalByTokenEvery15MinResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorWithdrawalByTokenEvery15Min'] = ResolversParentTypes['VAnchorWithdrawalByTokenEvery15Min']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenSymbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  startInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  endInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  withdrawal?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  averageWithdrawal?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  totalCount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorWithdrawalEvery15MinResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorWithdrawalEvery15Min'] = ResolversParentTypes['VAnchorWithdrawalEvery15Min']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  startInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  endInterval?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  withdrawal?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  averageWithdrawal?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  totalCount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type VAnchorWithdrawalLogResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['VAnchorWithdrawalLog'] = ResolversParentTypes['VAnchorWithdrawalLog']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  withdrawal?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  vAnchorAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenSymbol?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type WrappingEventLogResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['WrappingEventLog'] = ResolversParentTypes['WrappingEventLog']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  sender?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  recipient?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  tokenAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  wrappingFee?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  afterFeeAmount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type _Block_Resolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['_Block_'] = ResolversParentTypes['_Block_']> = ResolversObject<{
+  hash?: Resolver<Maybe<ResolversTypes['Bytes']>, ParentType, ContextType>;
+  number?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  timestamp?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type _Meta_Resolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['_Meta_'] = ResolversParentTypes['_Meta_']> = ResolversObject<{
+  block?: Resolver<ResolversTypes['_Block_'], ParentType, ContextType>;
+  deployment?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hasIndexingErrors?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type Resolvers<ContextType = MeshContext & { subgraphUrl: string }> = ResolversObject<{
+  Query?: QueryResolvers<ContextType>;
+  Subscription?: SubscriptionResolvers<ContextType>;
+  BigDecimal?: GraphQLScalarType;
+  BigInt?: GraphQLScalarType;
+  Bytes?: GraphQLScalarType;
+  EdgeAddition?: EdgeAdditionResolvers<ContextType>;
+  EdgeUpdate?: EdgeUpdateResolvers<ContextType>;
+  Encryptions?: EncryptionsResolvers<ContextType>;
+  ExternalData?: ExternalDataResolvers<ContextType>;
+  Insertion?: InsertionResolvers<ContextType>;
+  NewCommitment?: NewCommitmentResolvers<ContextType>;
+  NewNullifier?: NewNullifierResolvers<ContextType>;
+  PublicInputs?: PublicInputsResolvers<ContextType>;
+  PublicKey?: PublicKeyResolvers<ContextType>;
+  ShieldedTransaction?: ShieldedTransactionResolvers<ContextType>;
+  Token?: TokenResolvers<ContextType>;
+  UnwrappingEventLog?: UnwrappingEventLogResolvers<ContextType>;
+  VAnchorDeposit?: VAnchorDepositResolvers<ContextType>;
+  VAnchorDepositByToken?: VAnchorDepositByTokenResolvers<ContextType>;
+  VAnchorDepositByTokenEvery15Min?: VAnchorDepositByTokenEvery15MinResolvers<ContextType>;
+  VAnchorDepositEvery15Min?: VAnchorDepositEvery15MinResolvers<ContextType>;
+  VAnchorDepositLog?: VAnchorDepositLogResolvers<ContextType>;
+  VAnchorTotalRelayerFee?: VAnchorTotalRelayerFeeResolvers<ContextType>;
+  VAnchorTotalRelayerFee15Min?: VAnchorTotalRelayerFee15MinResolvers<ContextType>;
+  VAnchorTotalRelayerFeeByToken?: VAnchorTotalRelayerFeeByTokenResolvers<ContextType>;
+  VAnchorTotalRelayerFeeByTokenEvery15Min?: VAnchorTotalRelayerFeeByTokenEvery15MinResolvers<ContextType>;
+  VAnchorTotalValueLocked?: VAnchorTotalValueLockedResolvers<ContextType>;
+  VAnchorTotalValueLockedByToken?: VAnchorTotalValueLockedByTokenResolvers<ContextType>;
+  VAnchorTotalValueLockedByTokenEvery15Min?: VAnchorTotalValueLockedByTokenEvery15MinResolvers<ContextType>;
+  VAnchorTotalValueLockedEvery15Min?: VAnchorTotalValueLockedEvery15MinResolvers<ContextType>;
+  VAnchorTotalWrappingFee?: VAnchorTotalWrappingFeeResolvers<ContextType>;
+  VAnchorTotalWrappingFee15Min?: VAnchorTotalWrappingFee15MinResolvers<ContextType>;
+  VAnchorTotalWrappingFeeByToken?: VAnchorTotalWrappingFeeByTokenResolvers<ContextType>;
+  VAnchorTotalWrappingFeeByTokenEvery15Min?: VAnchorTotalWrappingFeeByTokenEvery15MinResolvers<ContextType>;
+  VAnchorTransferLog?: VAnchorTransferLogResolvers<ContextType>;
+  VAnchorWithdrawal?: VAnchorWithdrawalResolvers<ContextType>;
+  VAnchorWithdrawalByToken?: VAnchorWithdrawalByTokenResolvers<ContextType>;
+  VAnchorWithdrawalByTokenEvery15Min?: VAnchorWithdrawalByTokenEvery15MinResolvers<ContextType>;
+  VAnchorWithdrawalEvery15Min?: VAnchorWithdrawalEvery15MinResolvers<ContextType>;
+  VAnchorWithdrawalLog?: VAnchorWithdrawalLogResolvers<ContextType>;
+  WrappingEventLog?: WrappingEventLogResolvers<ContextType>;
+  _Block_?: _Block_Resolvers<ContextType>;
+  _Meta_?: _Meta_Resolvers<ContextType>;
+}>;
+
+export type DirectiveResolvers<ContextType = MeshContext & { subgraphUrl: string }> = ResolversObject<{
+  entity?: entityDirectiveResolver<any, any, ContextType>;
+  subgraphId?: subgraphIdDirectiveResolver<any, any, ContextType>;
+  derivedFrom?: derivedFromDirectiveResolver<any, any, ContextType>;
+}>;
+
+export type MeshContext = VanchorTypes.Context & BaseMeshContext;
+
+
+import { fileURLToPath } from '@graphql-mesh/utils';
+const baseDir = pathModule.join(pathModule.dirname(fileURLToPath(import.meta.url)), '..');
+
+const importFn: ImportFn = <T>(moduleId: string) => {
+  const relativeModuleId = (pathModule.isAbsolute(moduleId) ? pathModule.relative(baseDir, moduleId) : moduleId).split('\\').join('/').replace(baseDir + '/', '');
+  switch(relativeModuleId) {
+    case ".graphclient/sources/vanchor/introspectionSchema":
+      return Promise.resolve(importedModule$0) as T;
+    
+    default:
+      return Promise.reject(new Error(`Cannot find module '${relativeModuleId}'.`));
+  }
+};
+
+const rootStore = new MeshStore('.graphclient', new FsStoreStorageAdapter({
+  cwd: baseDir,
+  importFn,
+  fileType: "ts",
+}), {
+  readonly: true,
+  validate: false
+});
+
+export const rawServeConfig: YamlConfig.Config['serve'] = undefined as any
+export async function getMeshOptions(): Promise<GetMeshOptions> {
+const pubsub = new PubSub();
+const sourcesStore = rootStore.child('sources');
+const logger = new DefaultLogger("GraphClient");
+const cache = new (MeshCache as any)({
+      ...({} as any),
+      importFn,
+      store: rootStore.child('cache'),
+      pubsub,
+      logger,
+    } as any)
+
+const sources: MeshResolvedSource[] = [];
+const transforms: MeshTransform[] = [];
+const additionalEnvelopPlugins: MeshPlugin<any>[] = [];
+const vanchorTransforms = [];
+const vanchorHandler = new GraphqlHandler({
+              name: "vanchor",
+              config: {"endpoint":"{context.subgraphUrl:http://localhost:8000/subgraphs/name/VAnchorOrbitAthena}"},
+              baseDir,
+              cache,
+              pubsub,
+              store: sourcesStore.child("vanchor"),
+              logger: logger.child("vanchor"),
+              importFn,
+            });
+sources[0] = {
+          name: 'vanchor',
+          handler: vanchorHandler,
+          transforms: vanchorTransforms
+        }
+const additionalTypeDefs = [parse("extend type ShieldedTransaction {\n  subgraphUrl: String!\n}"),] as any[];
+const additionalResolvers = await Promise.all([
+        import("../src/resolvers.ts")
+            .then(m => m.resolvers || m.default || m)
+      ]);
+const merger = new(BareMerger as any)({
+        cache,
+        pubsub,
+        logger: logger.child('bareMerger'),
+        store: rootStore.child('bareMerger')
+      })
+
+  return {
+    sources,
+    transforms,
+    additionalTypeDefs,
+    additionalResolvers,
+    cache,
+    pubsub,
+    merger,
+    logger,
+    additionalEnvelopPlugins,
+    get documents() {
+      return [
+      
+    ];
+    },
+    fetchFn,
+  };
+}
+
+export function createBuiltMeshHTTPHandler<TServerContext = {}>(): MeshHTTPHandler<TServerContext> {
+  return createMeshHTTPHandler<TServerContext>({
+    baseDir,
+    getBuiltMesh: getBuiltGraphClient,
+    rawServeConfig: undefined,
+  })
+}
+
+
+let meshInstance$: Promise<MeshInstance> | undefined;
+
+export function getBuiltGraphClient(): Promise<MeshInstance> {
+  if (meshInstance$ == null) {
+    meshInstance$ = getMeshOptions().then(meshOptions => getMesh(meshOptions)).then(mesh => {
+      const id = mesh.pubsub.subscribe('destroy', () => {
+        meshInstance$ = undefined;
+        mesh.pubsub.unsubscribe(id);
+      });
+      return mesh;
+    });
+  }
+  return meshInstance$;
+}
+
+export const execute: ExecuteMeshFn = (...args) => getBuiltGraphClient().then(({ execute }) => execute(...args));
+
+export const subscribe: SubscribeMeshFn = (...args) => getBuiltGraphClient().then(({ subscribe }) => subscribe(...args));

--- a/packages/vanchor-client/.graphclient/schema.graphql
+++ b/packages/vanchor-client/.graphclient/schema.graphql
@@ -1,0 +1,5216 @@
+schema {
+  query: Query
+  subscription: Subscription
+}
+
+"Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive."
+directive @entity on OBJECT
+
+"Defined a Subgraph ID for an object type"
+directive @subgraphId(id: String!) on OBJECT
+
+"creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API."
+directive @derivedFrom(field: String!) on FIELD_DEFINITION
+
+type Query {
+  edgeAddition(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EdgeAddition
+  edgeAdditions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EdgeAddition_orderBy
+    orderDirection: OrderDirection
+    where: EdgeAddition_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EdgeAddition!]!
+  edgeUpdate(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EdgeUpdate
+  edgeUpdates(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EdgeUpdate_orderBy
+    orderDirection: OrderDirection
+    where: EdgeUpdate_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EdgeUpdate!]!
+  insertion(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Insertion
+  insertions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Insertion_orderBy
+    orderDirection: OrderDirection
+    where: Insertion_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Insertion!]!
+  newCommitment(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NewCommitment
+  newCommitments(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: NewCommitment_orderBy
+    orderDirection: OrderDirection
+    where: NewCommitment_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [NewCommitment!]!
+  newNullifier(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NewNullifier
+  newNullifiers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: NewNullifier_orderBy
+    orderDirection: OrderDirection
+    where: NewNullifier_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [NewNullifier!]!
+  publicKey(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): PublicKey
+  publicKeys(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: PublicKey_orderBy
+    orderDirection: OrderDirection
+    where: PublicKey_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [PublicKey!]!
+  token(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Token
+  tokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Token_orderBy
+    orderDirection: OrderDirection
+    where: Token_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Token!]!
+  externalData(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ExternalData
+  externalDatas(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ExternalData_orderBy
+    orderDirection: OrderDirection
+    where: ExternalData_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ExternalData!]!
+  publicInputs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: PublicInputs_orderBy
+    orderDirection: OrderDirection
+    where: PublicInputs_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [PublicInputs!]!
+  encryptions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Encryptions_orderBy
+    orderDirection: OrderDirection
+    where: Encryptions_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Encryptions!]!
+  shieldedTransaction(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ShieldedTransaction
+  shieldedTransactions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ShieldedTransaction_orderBy
+    orderDirection: OrderDirection
+    where: ShieldedTransaction_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ShieldedTransaction!]!
+  vanchorTotalValueLocked(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLocked
+  vanchorTotalValueLockeds(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLocked_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLocked_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLocked!]!
+  vanchorTotalValueLockedByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLockedByToken
+  vanchorTotalValueLockedByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLockedByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLockedByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLockedByToken!]!
+  vanchorTotalValueLockedEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLockedEvery15Min
+  vanchorTotalValueLockedEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLockedEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLockedEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLockedEvery15Min!]!
+  vanchorTotalValueLockedByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLockedByTokenEvery15Min
+  vanchorTotalValueLockedByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLockedByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLockedByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLockedByTokenEvery15Min!]!
+  vanchorTotalRelayerFee(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFee
+  vanchorTotalRelayerFees(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFee_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFee_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFee!]!
+  vanchorTotalRelayerFeeByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFeeByToken
+  vanchorTotalRelayerFeeByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFeeByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFeeByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFeeByToken!]!
+  vanchorTotalRelayerFee15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFee15Min
+  vanchorTotalRelayerFee15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFee15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFee15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFee15Min!]!
+  vanchorTotalRelayerFeeByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFeeByTokenEvery15Min
+  vanchorTotalRelayerFeeByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFeeByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFeeByTokenEvery15Min!]!
+  vanchorTotalWrappingFee(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFee
+  vanchorTotalWrappingFees(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFee_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFee_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFee!]!
+  vanchorTotalWrappingFeeByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFeeByToken
+  vanchorTotalWrappingFeeByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFeeByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFeeByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFeeByToken!]!
+  vanchorTotalWrappingFee15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFee15Min
+  vanchorTotalWrappingFee15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFee15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFee15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFee15Min!]!
+  vanchorTotalWrappingFeeByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFeeByTokenEvery15Min
+  vanchorTotalWrappingFeeByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFeeByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFeeByTokenEvery15Min!]!
+  wrappingEventLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): WrappingEventLog
+  wrappingEventLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: WrappingEventLog_orderBy
+    orderDirection: OrderDirection
+    where: WrappingEventLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [WrappingEventLog!]!
+  unwrappingEventLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): UnwrappingEventLog
+  unwrappingEventLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: UnwrappingEventLog_orderBy
+    orderDirection: OrderDirection
+    where: UnwrappingEventLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [UnwrappingEventLog!]!
+  vanchorWithdrawalLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalLog
+  vanchorWithdrawalLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalLog_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalLog!]!
+  vanchorWithdrawal(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawal
+  vanchorWithdrawals(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawal_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawal_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawal!]!
+  vanchorWithdrawalByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalByToken
+  vanchorWithdrawalByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalByToken!]!
+  vanchorWithdrawalEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalEvery15Min
+  vanchorWithdrawalEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalEvery15Min!]!
+  vanchorWithdrawalByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalByTokenEvery15Min
+  vanchorWithdrawalByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalByTokenEvery15Min!]!
+  vanchorDeposit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDeposit
+  vanchorDeposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDeposit_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDeposit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDeposit!]!
+  vanchorDepositByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositByToken
+  vanchorDepositByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositByToken!]!
+  vanchorDepositEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositEvery15Min
+  vanchorDepositEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositEvery15Min!]!
+  vanchorDepositByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositByTokenEvery15Min
+  vanchorDepositByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositByTokenEvery15Min!]!
+  vanchorDepositLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositLog
+  vanchorDepositLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositLog_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositLog!]!
+  vanchorTransferLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTransferLog
+  vanchorTransferLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTransferLog_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTransferLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTransferLog!]!
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
+}
+
+type Subscription {
+  edgeAddition(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EdgeAddition
+  edgeAdditions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EdgeAddition_orderBy
+    orderDirection: OrderDirection
+    where: EdgeAddition_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EdgeAddition!]!
+  edgeUpdate(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EdgeUpdate
+  edgeUpdates(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EdgeUpdate_orderBy
+    orderDirection: OrderDirection
+    where: EdgeUpdate_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EdgeUpdate!]!
+  insertion(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Insertion
+  insertions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Insertion_orderBy
+    orderDirection: OrderDirection
+    where: Insertion_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Insertion!]!
+  newCommitment(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NewCommitment
+  newCommitments(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: NewCommitment_orderBy
+    orderDirection: OrderDirection
+    where: NewCommitment_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [NewCommitment!]!
+  newNullifier(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NewNullifier
+  newNullifiers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: NewNullifier_orderBy
+    orderDirection: OrderDirection
+    where: NewNullifier_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [NewNullifier!]!
+  publicKey(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): PublicKey
+  publicKeys(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: PublicKey_orderBy
+    orderDirection: OrderDirection
+    where: PublicKey_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [PublicKey!]!
+  token(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Token
+  tokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Token_orderBy
+    orderDirection: OrderDirection
+    where: Token_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Token!]!
+  externalData(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ExternalData
+  externalDatas(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ExternalData_orderBy
+    orderDirection: OrderDirection
+    where: ExternalData_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ExternalData!]!
+  publicInputs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: PublicInputs_orderBy
+    orderDirection: OrderDirection
+    where: PublicInputs_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [PublicInputs!]!
+  encryptions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Encryptions_orderBy
+    orderDirection: OrderDirection
+    where: Encryptions_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Encryptions!]!
+  shieldedTransaction(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ShieldedTransaction
+  shieldedTransactions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ShieldedTransaction_orderBy
+    orderDirection: OrderDirection
+    where: ShieldedTransaction_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ShieldedTransaction!]!
+  vanchorTotalValueLocked(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLocked
+  vanchorTotalValueLockeds(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLocked_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLocked_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLocked!]!
+  vanchorTotalValueLockedByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLockedByToken
+  vanchorTotalValueLockedByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLockedByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLockedByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLockedByToken!]!
+  vanchorTotalValueLockedEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLockedEvery15Min
+  vanchorTotalValueLockedEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLockedEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLockedEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLockedEvery15Min!]!
+  vanchorTotalValueLockedByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLockedByTokenEvery15Min
+  vanchorTotalValueLockedByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLockedByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLockedByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLockedByTokenEvery15Min!]!
+  vanchorTotalRelayerFee(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFee
+  vanchorTotalRelayerFees(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFee_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFee_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFee!]!
+  vanchorTotalRelayerFeeByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFeeByToken
+  vanchorTotalRelayerFeeByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFeeByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFeeByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFeeByToken!]!
+  vanchorTotalRelayerFee15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFee15Min
+  vanchorTotalRelayerFee15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFee15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFee15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFee15Min!]!
+  vanchorTotalRelayerFeeByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFeeByTokenEvery15Min
+  vanchorTotalRelayerFeeByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFeeByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFeeByTokenEvery15Min!]!
+  vanchorTotalWrappingFee(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFee
+  vanchorTotalWrappingFees(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFee_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFee_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFee!]!
+  vanchorTotalWrappingFeeByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFeeByToken
+  vanchorTotalWrappingFeeByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFeeByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFeeByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFeeByToken!]!
+  vanchorTotalWrappingFee15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFee15Min
+  vanchorTotalWrappingFee15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFee15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFee15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFee15Min!]!
+  vanchorTotalWrappingFeeByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFeeByTokenEvery15Min
+  vanchorTotalWrappingFeeByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFeeByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFeeByTokenEvery15Min!]!
+  wrappingEventLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): WrappingEventLog
+  wrappingEventLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: WrappingEventLog_orderBy
+    orderDirection: OrderDirection
+    where: WrappingEventLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [WrappingEventLog!]!
+  unwrappingEventLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): UnwrappingEventLog
+  unwrappingEventLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: UnwrappingEventLog_orderBy
+    orderDirection: OrderDirection
+    where: UnwrappingEventLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [UnwrappingEventLog!]!
+  vanchorWithdrawalLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalLog
+  vanchorWithdrawalLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalLog_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalLog!]!
+  vanchorWithdrawal(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawal
+  vanchorWithdrawals(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawal_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawal_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawal!]!
+  vanchorWithdrawalByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalByToken
+  vanchorWithdrawalByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalByToken!]!
+  vanchorWithdrawalEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalEvery15Min
+  vanchorWithdrawalEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalEvery15Min!]!
+  vanchorWithdrawalByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalByTokenEvery15Min
+  vanchorWithdrawalByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalByTokenEvery15Min!]!
+  vanchorDeposit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDeposit
+  vanchorDeposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDeposit_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDeposit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDeposit!]!
+  vanchorDepositByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositByToken
+  vanchorDepositByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositByToken!]!
+  vanchorDepositEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositEvery15Min
+  vanchorDepositEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositEvery15Min!]!
+  vanchorDepositByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositByTokenEvery15Min
+  vanchorDepositByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositByTokenEvery15Min!]!
+  vanchorDepositLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositLog
+  vanchorDepositLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositLog_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositLog!]!
+  vanchorTransferLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTransferLog
+  vanchorTransferLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTransferLog_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTransferLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTransferLog!]!
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
+}
+
+scalar BigDecimal
+
+scalar BigInt
+
+input BlockChangedFilter {
+  number_gte: Int!
+}
+
+input Block_height {
+  hash: Bytes
+  number: Int
+  number_gte: Int
+}
+
+scalar Bytes
+
+type EdgeAddition {
+  id: Bytes!
+  chainID: BigInt!
+  latestLeafIndex: BigInt!
+  merkleRoot: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+input EdgeAddition_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  chainID: BigInt
+  chainID_not: BigInt
+  chainID_gt: BigInt
+  chainID_lt: BigInt
+  chainID_gte: BigInt
+  chainID_lte: BigInt
+  chainID_in: [BigInt!]
+  chainID_not_in: [BigInt!]
+  latestLeafIndex: BigInt
+  latestLeafIndex_not: BigInt
+  latestLeafIndex_gt: BigInt
+  latestLeafIndex_lt: BigInt
+  latestLeafIndex_gte: BigInt
+  latestLeafIndex_lte: BigInt
+  latestLeafIndex_in: [BigInt!]
+  latestLeafIndex_not_in: [BigInt!]
+  merkleRoot: BigInt
+  merkleRoot_not: BigInt
+  merkleRoot_gt: BigInt
+  merkleRoot_lt: BigInt
+  merkleRoot_gte: BigInt
+  merkleRoot_lte: BigInt
+  merkleRoot_in: [BigInt!]
+  merkleRoot_not_in: [BigInt!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [EdgeAddition_filter]
+  or: [EdgeAddition_filter]
+}
+
+enum EdgeAddition_orderBy {
+  id
+  chainID
+  latestLeafIndex
+  merkleRoot
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+type EdgeUpdate {
+  id: Bytes!
+  chainID: BigInt!
+  latestLeafIndex: BigInt!
+  merkleRoot: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+input EdgeUpdate_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  chainID: BigInt
+  chainID_not: BigInt
+  chainID_gt: BigInt
+  chainID_lt: BigInt
+  chainID_gte: BigInt
+  chainID_lte: BigInt
+  chainID_in: [BigInt!]
+  chainID_not_in: [BigInt!]
+  latestLeafIndex: BigInt
+  latestLeafIndex_not: BigInt
+  latestLeafIndex_gt: BigInt
+  latestLeafIndex_lt: BigInt
+  latestLeafIndex_gte: BigInt
+  latestLeafIndex_lte: BigInt
+  latestLeafIndex_in: [BigInt!]
+  latestLeafIndex_not_in: [BigInt!]
+  merkleRoot: BigInt
+  merkleRoot_not: BigInt
+  merkleRoot_gt: BigInt
+  merkleRoot_lt: BigInt
+  merkleRoot_gte: BigInt
+  merkleRoot_lte: BigInt
+  merkleRoot_in: [BigInt!]
+  merkleRoot_not_in: [BigInt!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [EdgeUpdate_filter]
+  or: [EdgeUpdate_filter]
+}
+
+enum EdgeUpdate_orderBy {
+  id
+  chainID
+  latestLeafIndex
+  merkleRoot
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+type Encryptions {
+  id: Bytes!
+  encryptedOutput1: Bytes!
+  encryptedOutput2: Bytes!
+}
+
+input Encryptions_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  encryptedOutput1: Bytes
+  encryptedOutput1_not: Bytes
+  encryptedOutput1_gt: Bytes
+  encryptedOutput1_lt: Bytes
+  encryptedOutput1_gte: Bytes
+  encryptedOutput1_lte: Bytes
+  encryptedOutput1_in: [Bytes!]
+  encryptedOutput1_not_in: [Bytes!]
+  encryptedOutput1_contains: Bytes
+  encryptedOutput1_not_contains: Bytes
+  encryptedOutput2: Bytes
+  encryptedOutput2_not: Bytes
+  encryptedOutput2_gt: Bytes
+  encryptedOutput2_lt: Bytes
+  encryptedOutput2_gte: Bytes
+  encryptedOutput2_lte: Bytes
+  encryptedOutput2_in: [Bytes!]
+  encryptedOutput2_not_in: [Bytes!]
+  encryptedOutput2_contains: Bytes
+  encryptedOutput2_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Encryptions_filter]
+  or: [Encryptions_filter]
+}
+
+enum Encryptions_orderBy {
+  id
+  encryptedOutput1
+  encryptedOutput2
+}
+
+type ExternalData {
+  id: Bytes!
+  recipient: Bytes!
+  extAmount: BigInt!
+  relayer: Bytes!
+  fee: BigInt!
+  refund: BigInt!
+  token: String!
+}
+
+input ExternalData_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  recipient: Bytes
+  recipient_not: Bytes
+  recipient_gt: Bytes
+  recipient_lt: Bytes
+  recipient_gte: Bytes
+  recipient_lte: Bytes
+  recipient_in: [Bytes!]
+  recipient_not_in: [Bytes!]
+  recipient_contains: Bytes
+  recipient_not_contains: Bytes
+  extAmount: BigInt
+  extAmount_not: BigInt
+  extAmount_gt: BigInt
+  extAmount_lt: BigInt
+  extAmount_gte: BigInt
+  extAmount_lte: BigInt
+  extAmount_in: [BigInt!]
+  extAmount_not_in: [BigInt!]
+  relayer: Bytes
+  relayer_not: Bytes
+  relayer_gt: Bytes
+  relayer_lt: Bytes
+  relayer_gte: Bytes
+  relayer_lte: Bytes
+  relayer_in: [Bytes!]
+  relayer_not_in: [Bytes!]
+  relayer_contains: Bytes
+  relayer_not_contains: Bytes
+  fee: BigInt
+  fee_not: BigInt
+  fee_gt: BigInt
+  fee_lt: BigInt
+  fee_gte: BigInt
+  fee_lte: BigInt
+  fee_in: [BigInt!]
+  fee_not_in: [BigInt!]
+  refund: BigInt
+  refund_not: BigInt
+  refund_gt: BigInt
+  refund_lt: BigInt
+  refund_gte: BigInt
+  refund_lte: BigInt
+  refund_in: [BigInt!]
+  refund_not_in: [BigInt!]
+  token: String
+  token_not: String
+  token_gt: String
+  token_lt: String
+  token_gte: String
+  token_lte: String
+  token_in: [String!]
+  token_not_in: [String!]
+  token_contains: String
+  token_contains_nocase: String
+  token_not_contains: String
+  token_not_contains_nocase: String
+  token_starts_with: String
+  token_starts_with_nocase: String
+  token_not_starts_with: String
+  token_not_starts_with_nocase: String
+  token_ends_with: String
+  token_ends_with_nocase: String
+  token_not_ends_with: String
+  token_not_ends_with_nocase: String
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ExternalData_filter]
+  or: [ExternalData_filter]
+}
+
+enum ExternalData_orderBy {
+  id
+  recipient
+  extAmount
+  relayer
+  fee
+  refund
+  token
+}
+
+type Insertion {
+  id: Bytes!
+  commitment: BigInt!
+  leafIndex: BigInt!
+  timestamp: BigInt!
+  newMerkleRoot: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+input Insertion_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  commitment: BigInt
+  commitment_not: BigInt
+  commitment_gt: BigInt
+  commitment_lt: BigInt
+  commitment_gte: BigInt
+  commitment_lte: BigInt
+  commitment_in: [BigInt!]
+  commitment_not_in: [BigInt!]
+  leafIndex: BigInt
+  leafIndex_not: BigInt
+  leafIndex_gt: BigInt
+  leafIndex_lt: BigInt
+  leafIndex_gte: BigInt
+  leafIndex_lte: BigInt
+  leafIndex_in: [BigInt!]
+  leafIndex_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  newMerkleRoot: BigInt
+  newMerkleRoot_not: BigInt
+  newMerkleRoot_gt: BigInt
+  newMerkleRoot_lt: BigInt
+  newMerkleRoot_gte: BigInt
+  newMerkleRoot_lte: BigInt
+  newMerkleRoot_in: [BigInt!]
+  newMerkleRoot_not_in: [BigInt!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Insertion_filter]
+  or: [Insertion_filter]
+}
+
+enum Insertion_orderBy {
+  id
+  commitment
+  leafIndex
+  timestamp
+  newMerkleRoot
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+type NewCommitment {
+  id: Bytes!
+  commitment: BigInt!
+  subTreeIndex: BigInt!
+  leafIndex: BigInt!
+  encryptedOutput: Bytes!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+input NewCommitment_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  commitment: BigInt
+  commitment_not: BigInt
+  commitment_gt: BigInt
+  commitment_lt: BigInt
+  commitment_gte: BigInt
+  commitment_lte: BigInt
+  commitment_in: [BigInt!]
+  commitment_not_in: [BigInt!]
+  subTreeIndex: BigInt
+  subTreeIndex_not: BigInt
+  subTreeIndex_gt: BigInt
+  subTreeIndex_lt: BigInt
+  subTreeIndex_gte: BigInt
+  subTreeIndex_lte: BigInt
+  subTreeIndex_in: [BigInt!]
+  subTreeIndex_not_in: [BigInt!]
+  leafIndex: BigInt
+  leafIndex_not: BigInt
+  leafIndex_gt: BigInt
+  leafIndex_lt: BigInt
+  leafIndex_gte: BigInt
+  leafIndex_lte: BigInt
+  leafIndex_in: [BigInt!]
+  leafIndex_not_in: [BigInt!]
+  encryptedOutput: Bytes
+  encryptedOutput_not: Bytes
+  encryptedOutput_gt: Bytes
+  encryptedOutput_lt: Bytes
+  encryptedOutput_gte: Bytes
+  encryptedOutput_lte: Bytes
+  encryptedOutput_in: [Bytes!]
+  encryptedOutput_not_in: [Bytes!]
+  encryptedOutput_contains: Bytes
+  encryptedOutput_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NewCommitment_filter]
+  or: [NewCommitment_filter]
+}
+
+enum NewCommitment_orderBy {
+  id
+  commitment
+  subTreeIndex
+  leafIndex
+  encryptedOutput
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+type NewNullifier {
+  id: Bytes!
+  nullifier: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+input NewNullifier_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  nullifier: BigInt
+  nullifier_not: BigInt
+  nullifier_gt: BigInt
+  nullifier_lt: BigInt
+  nullifier_gte: BigInt
+  nullifier_lte: BigInt
+  nullifier_in: [BigInt!]
+  nullifier_not_in: [BigInt!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NewNullifier_filter]
+  or: [NewNullifier_filter]
+}
+
+enum NewNullifier_orderBy {
+  id
+  nullifier
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+"""Defines the order direction, either ascending or descending"""
+enum OrderDirection {
+  asc
+  desc
+}
+
+type PublicInputs {
+  id: Bytes!
+  roots: Bytes!
+  extensionRoots: Bytes!
+  inputNullifiers: [BigInt!]!
+  outputCommitments: [BigInt!]!
+  publicAmount: BigInt!
+  extDataHash: BigInt!
+}
+
+input PublicInputs_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  roots: Bytes
+  roots_not: Bytes
+  roots_gt: Bytes
+  roots_lt: Bytes
+  roots_gte: Bytes
+  roots_lte: Bytes
+  roots_in: [Bytes!]
+  roots_not_in: [Bytes!]
+  roots_contains: Bytes
+  roots_not_contains: Bytes
+  extensionRoots: Bytes
+  extensionRoots_not: Bytes
+  extensionRoots_gt: Bytes
+  extensionRoots_lt: Bytes
+  extensionRoots_gte: Bytes
+  extensionRoots_lte: Bytes
+  extensionRoots_in: [Bytes!]
+  extensionRoots_not_in: [Bytes!]
+  extensionRoots_contains: Bytes
+  extensionRoots_not_contains: Bytes
+  inputNullifiers: [BigInt!]
+  inputNullifiers_not: [BigInt!]
+  inputNullifiers_contains: [BigInt!]
+  inputNullifiers_contains_nocase: [BigInt!]
+  inputNullifiers_not_contains: [BigInt!]
+  inputNullifiers_not_contains_nocase: [BigInt!]
+  outputCommitments: [BigInt!]
+  outputCommitments_not: [BigInt!]
+  outputCommitments_contains: [BigInt!]
+  outputCommitments_contains_nocase: [BigInt!]
+  outputCommitments_not_contains: [BigInt!]
+  outputCommitments_not_contains_nocase: [BigInt!]
+  publicAmount: BigInt
+  publicAmount_not: BigInt
+  publicAmount_gt: BigInt
+  publicAmount_lt: BigInt
+  publicAmount_gte: BigInt
+  publicAmount_lte: BigInt
+  publicAmount_in: [BigInt!]
+  publicAmount_not_in: [BigInt!]
+  extDataHash: BigInt
+  extDataHash_not: BigInt
+  extDataHash_gt: BigInt
+  extDataHash_lt: BigInt
+  extDataHash_gte: BigInt
+  extDataHash_lte: BigInt
+  extDataHash_in: [BigInt!]
+  extDataHash_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [PublicInputs_filter]
+  or: [PublicInputs_filter]
+}
+
+enum PublicInputs_orderBy {
+  id
+  roots
+  extensionRoots
+  inputNullifiers
+  outputCommitments
+  publicAmount
+  extDataHash
+}
+
+type PublicKey {
+  id: Bytes!
+  owner: Bytes!
+  key: Bytes!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+input PublicKey_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  owner: Bytes
+  owner_not: Bytes
+  owner_gt: Bytes
+  owner_lt: Bytes
+  owner_gte: Bytes
+  owner_lte: Bytes
+  owner_in: [Bytes!]
+  owner_not_in: [Bytes!]
+  owner_contains: Bytes
+  owner_not_contains: Bytes
+  key: Bytes
+  key_not: Bytes
+  key_gt: Bytes
+  key_lt: Bytes
+  key_gte: Bytes
+  key_lte: Bytes
+  key_in: [Bytes!]
+  key_not_in: [Bytes!]
+  key_contains: Bytes
+  key_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [PublicKey_filter]
+  or: [PublicKey_filter]
+}
+
+enum PublicKey_orderBy {
+  id
+  owner
+  key
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+type ShieldedTransaction {
+  id: Bytes!
+  vanchor: Bytes!
+  sender: Bytes!
+  value: BigInt!
+  proof: Bytes!
+  auxPublicInputs: Bytes!
+  externalData: ExternalData!
+  publicInputs: PublicInputs!
+  encryptions: Encryptions!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+  subgraphUrl: String!
+}
+
+input ShieldedTransaction_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  vanchor: Bytes
+  vanchor_not: Bytes
+  vanchor_gt: Bytes
+  vanchor_lt: Bytes
+  vanchor_gte: Bytes
+  vanchor_lte: Bytes
+  vanchor_in: [Bytes!]
+  vanchor_not_in: [Bytes!]
+  vanchor_contains: Bytes
+  vanchor_not_contains: Bytes
+  sender: Bytes
+  sender_not: Bytes
+  sender_gt: Bytes
+  sender_lt: Bytes
+  sender_gte: Bytes
+  sender_lte: Bytes
+  sender_in: [Bytes!]
+  sender_not_in: [Bytes!]
+  sender_contains: Bytes
+  sender_not_contains: Bytes
+  value: BigInt
+  value_not: BigInt
+  value_gt: BigInt
+  value_lt: BigInt
+  value_gte: BigInt
+  value_lte: BigInt
+  value_in: [BigInt!]
+  value_not_in: [BigInt!]
+  proof: Bytes
+  proof_not: Bytes
+  proof_gt: Bytes
+  proof_lt: Bytes
+  proof_gte: Bytes
+  proof_lte: Bytes
+  proof_in: [Bytes!]
+  proof_not_in: [Bytes!]
+  proof_contains: Bytes
+  proof_not_contains: Bytes
+  auxPublicInputs: Bytes
+  auxPublicInputs_not: Bytes
+  auxPublicInputs_gt: Bytes
+  auxPublicInputs_lt: Bytes
+  auxPublicInputs_gte: Bytes
+  auxPublicInputs_lte: Bytes
+  auxPublicInputs_in: [Bytes!]
+  auxPublicInputs_not_in: [Bytes!]
+  auxPublicInputs_contains: Bytes
+  auxPublicInputs_not_contains: Bytes
+  externalData: String
+  externalData_not: String
+  externalData_gt: String
+  externalData_lt: String
+  externalData_gte: String
+  externalData_lte: String
+  externalData_in: [String!]
+  externalData_not_in: [String!]
+  externalData_contains: String
+  externalData_contains_nocase: String
+  externalData_not_contains: String
+  externalData_not_contains_nocase: String
+  externalData_starts_with: String
+  externalData_starts_with_nocase: String
+  externalData_not_starts_with: String
+  externalData_not_starts_with_nocase: String
+  externalData_ends_with: String
+  externalData_ends_with_nocase: String
+  externalData_not_ends_with: String
+  externalData_not_ends_with_nocase: String
+  externalData_: ExternalData_filter
+  publicInputs: String
+  publicInputs_not: String
+  publicInputs_gt: String
+  publicInputs_lt: String
+  publicInputs_gte: String
+  publicInputs_lte: String
+  publicInputs_in: [String!]
+  publicInputs_not_in: [String!]
+  publicInputs_contains: String
+  publicInputs_contains_nocase: String
+  publicInputs_not_contains: String
+  publicInputs_not_contains_nocase: String
+  publicInputs_starts_with: String
+  publicInputs_starts_with_nocase: String
+  publicInputs_not_starts_with: String
+  publicInputs_not_starts_with_nocase: String
+  publicInputs_ends_with: String
+  publicInputs_ends_with_nocase: String
+  publicInputs_not_ends_with: String
+  publicInputs_not_ends_with_nocase: String
+  publicInputs_: PublicInputs_filter
+  encryptions: String
+  encryptions_not: String
+  encryptions_gt: String
+  encryptions_lt: String
+  encryptions_gte: String
+  encryptions_lte: String
+  encryptions_in: [String!]
+  encryptions_not_in: [String!]
+  encryptions_contains: String
+  encryptions_contains_nocase: String
+  encryptions_not_contains: String
+  encryptions_not_contains_nocase: String
+  encryptions_starts_with: String
+  encryptions_starts_with_nocase: String
+  encryptions_not_starts_with: String
+  encryptions_not_starts_with_nocase: String
+  encryptions_ends_with: String
+  encryptions_ends_with_nocase: String
+  encryptions_not_ends_with: String
+  encryptions_not_ends_with_nocase: String
+  encryptions_: Encryptions_filter
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ShieldedTransaction_filter]
+  or: [ShieldedTransaction_filter]
+}
+
+enum ShieldedTransaction_orderBy {
+  id
+  vanchor
+  sender
+  value
+  proof
+  auxPublicInputs
+  externalData
+  externalData__id
+  externalData__recipient
+  externalData__extAmount
+  externalData__relayer
+  externalData__fee
+  externalData__refund
+  externalData__token
+  publicInputs
+  publicInputs__id
+  publicInputs__roots
+  publicInputs__extensionRoots
+  publicInputs__publicAmount
+  publicInputs__extDataHash
+  encryptions
+  encryptions__id
+  encryptions__encryptedOutput1
+  encryptions__encryptedOutput2
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+type Token {
+  id: Bytes!
+  address: Bytes!
+  decimals: Int!
+  name: String!
+  symbol: String!
+}
+
+input Token_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  address: Bytes
+  address_not: Bytes
+  address_gt: Bytes
+  address_lt: Bytes
+  address_gte: Bytes
+  address_lte: Bytes
+  address_in: [Bytes!]
+  address_not_in: [Bytes!]
+  address_contains: Bytes
+  address_not_contains: Bytes
+  decimals: Int
+  decimals_not: Int
+  decimals_gt: Int
+  decimals_lt: Int
+  decimals_gte: Int
+  decimals_lte: Int
+  decimals_in: [Int!]
+  decimals_not_in: [Int!]
+  name: String
+  name_not: String
+  name_gt: String
+  name_lt: String
+  name_gte: String
+  name_lte: String
+  name_in: [String!]
+  name_not_in: [String!]
+  name_contains: String
+  name_contains_nocase: String
+  name_not_contains: String
+  name_not_contains_nocase: String
+  name_starts_with: String
+  name_starts_with_nocase: String
+  name_not_starts_with: String
+  name_not_starts_with_nocase: String
+  name_ends_with: String
+  name_ends_with_nocase: String
+  name_not_ends_with: String
+  name_not_ends_with_nocase: String
+  symbol: String
+  symbol_not: String
+  symbol_gt: String
+  symbol_lt: String
+  symbol_gte: String
+  symbol_lte: String
+  symbol_in: [String!]
+  symbol_not_in: [String!]
+  symbol_contains: String
+  symbol_contains_nocase: String
+  symbol_not_contains: String
+  symbol_not_contains_nocase: String
+  symbol_starts_with: String
+  symbol_starts_with_nocase: String
+  symbol_not_starts_with: String
+  symbol_not_starts_with_nocase: String
+  symbol_ends_with: String
+  symbol_ends_with_nocase: String
+  symbol_not_ends_with: String
+  symbol_not_ends_with_nocase: String
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Token_filter]
+  or: [Token_filter]
+}
+
+enum Token_orderBy {
+  id
+  address
+  decimals
+  name
+  symbol
+}
+
+type UnwrappingEventLog {
+  id: String!
+  sender: Bytes!
+  recipient: Bytes!
+  tokenAddress: Bytes!
+  amount: BigInt!
+  timestamp: BigInt!
+}
+
+input UnwrappingEventLog_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  sender: Bytes
+  sender_not: Bytes
+  sender_gt: Bytes
+  sender_lt: Bytes
+  sender_gte: Bytes
+  sender_lte: Bytes
+  sender_in: [Bytes!]
+  sender_not_in: [Bytes!]
+  sender_contains: Bytes
+  sender_not_contains: Bytes
+  recipient: Bytes
+  recipient_not: Bytes
+  recipient_gt: Bytes
+  recipient_lt: Bytes
+  recipient_gte: Bytes
+  recipient_lte: Bytes
+  recipient_in: [Bytes!]
+  recipient_not_in: [Bytes!]
+  recipient_contains: Bytes
+  recipient_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  amount: BigInt
+  amount_not: BigInt
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  amount_in: [BigInt!]
+  amount_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [UnwrappingEventLog_filter]
+  or: [UnwrappingEventLog_filter]
+}
+
+enum UnwrappingEventLog_orderBy {
+  id
+  sender
+  recipient
+  tokenAddress
+  amount
+  timestamp
+}
+
+type VAnchorDeposit {
+  id: String!
+  deposit: BigInt!
+  averageDeposit: BigInt!
+  totalCount: BigInt!
+}
+
+type VAnchorDepositByToken {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  deposit: BigInt!
+  averageDeposit: BigInt!
+  totalCount: BigInt!
+}
+
+type VAnchorDepositByTokenEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  deposit: BigInt!
+  averageDeposit: BigInt!
+  totalCount: BigInt!
+}
+
+input VAnchorDepositByTokenEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  deposit: BigInt
+  deposit_not: BigInt
+  deposit_gt: BigInt
+  deposit_lt: BigInt
+  deposit_gte: BigInt
+  deposit_lte: BigInt
+  deposit_in: [BigInt!]
+  deposit_not_in: [BigInt!]
+  averageDeposit: BigInt
+  averageDeposit_not: BigInt
+  averageDeposit_gt: BigInt
+  averageDeposit_lt: BigInt
+  averageDeposit_gte: BigInt
+  averageDeposit_lte: BigInt
+  averageDeposit_in: [BigInt!]
+  averageDeposit_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorDepositByTokenEvery15Min_filter]
+  or: [VAnchorDepositByTokenEvery15Min_filter]
+}
+
+enum VAnchorDepositByTokenEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  startInterval
+  endInterval
+  deposit
+  averageDeposit
+  totalCount
+}
+
+input VAnchorDepositByToken_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  deposit: BigInt
+  deposit_not: BigInt
+  deposit_gt: BigInt
+  deposit_lt: BigInt
+  deposit_gte: BigInt
+  deposit_lte: BigInt
+  deposit_in: [BigInt!]
+  deposit_not_in: [BigInt!]
+  averageDeposit: BigInt
+  averageDeposit_not: BigInt
+  averageDeposit_gt: BigInt
+  averageDeposit_lt: BigInt
+  averageDeposit_gte: BigInt
+  averageDeposit_lte: BigInt
+  averageDeposit_in: [BigInt!]
+  averageDeposit_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorDepositByToken_filter]
+  or: [VAnchorDepositByToken_filter]
+}
+
+enum VAnchorDepositByToken_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  deposit
+  averageDeposit
+  totalCount
+}
+
+type VAnchorDepositEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  deposit: BigInt!
+  averageDeposit: BigInt!
+  totalCount: BigInt!
+}
+
+input VAnchorDepositEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  deposit: BigInt
+  deposit_not: BigInt
+  deposit_gt: BigInt
+  deposit_lt: BigInt
+  deposit_gte: BigInt
+  deposit_lte: BigInt
+  deposit_in: [BigInt!]
+  deposit_not_in: [BigInt!]
+  averageDeposit: BigInt
+  averageDeposit_not: BigInt
+  averageDeposit_gt: BigInt
+  averageDeposit_lt: BigInt
+  averageDeposit_gte: BigInt
+  averageDeposit_lte: BigInt
+  averageDeposit_in: [BigInt!]
+  averageDeposit_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorDepositEvery15Min_filter]
+  or: [VAnchorDepositEvery15Min_filter]
+}
+
+enum VAnchorDepositEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  startInterval
+  endInterval
+  deposit
+  averageDeposit
+  totalCount
+}
+
+type VAnchorDepositLog {
+  id: String!
+  deposit: BigInt!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  timestamp: BigInt!
+}
+
+input VAnchorDepositLog_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  deposit: BigInt
+  deposit_not: BigInt
+  deposit_gt: BigInt
+  deposit_lt: BigInt
+  deposit_gte: BigInt
+  deposit_lte: BigInt
+  deposit_in: [BigInt!]
+  deposit_not_in: [BigInt!]
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorDepositLog_filter]
+  or: [VAnchorDepositLog_filter]
+}
+
+enum VAnchorDepositLog_orderBy {
+  id
+  deposit
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  timestamp
+}
+
+input VAnchorDeposit_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  deposit: BigInt
+  deposit_not: BigInt
+  deposit_gt: BigInt
+  deposit_lt: BigInt
+  deposit_gte: BigInt
+  deposit_lte: BigInt
+  deposit_in: [BigInt!]
+  deposit_not_in: [BigInt!]
+  averageDeposit: BigInt
+  averageDeposit_not: BigInt
+  averageDeposit_gt: BigInt
+  averageDeposit_lt: BigInt
+  averageDeposit_gte: BigInt
+  averageDeposit_lte: BigInt
+  averageDeposit_in: [BigInt!]
+  averageDeposit_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorDeposit_filter]
+  or: [VAnchorDeposit_filter]
+}
+
+enum VAnchorDeposit_orderBy {
+  id
+  deposit
+  averageDeposit
+  totalCount
+}
+
+type VAnchorTotalRelayerFee {
+  id: String!
+  fees: BigInt!
+}
+
+type VAnchorTotalRelayerFee15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  fees: BigInt!
+}
+
+input VAnchorTotalRelayerFee15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalRelayerFee15Min_filter]
+  or: [VAnchorTotalRelayerFee15Min_filter]
+}
+
+enum VAnchorTotalRelayerFee15Min_orderBy {
+  id
+  vAnchorAddress
+  startInterval
+  endInterval
+  fees
+}
+
+type VAnchorTotalRelayerFeeByToken {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenSymbol: String!
+  tokenAddress: Bytes!
+  fees: BigInt!
+}
+
+type VAnchorTotalRelayerFeeByTokenEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  fees: BigInt!
+}
+
+input VAnchorTotalRelayerFeeByTokenEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalRelayerFeeByTokenEvery15Min_filter]
+  or: [VAnchorTotalRelayerFeeByTokenEvery15Min_filter]
+}
+
+enum VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  startInterval
+  endInterval
+  fees
+}
+
+input VAnchorTotalRelayerFeeByToken_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalRelayerFeeByToken_filter]
+  or: [VAnchorTotalRelayerFeeByToken_filter]
+}
+
+enum VAnchorTotalRelayerFeeByToken_orderBy {
+  id
+  vAnchorAddress
+  tokenSymbol
+  tokenAddress
+  fees
+}
+
+input VAnchorTotalRelayerFee_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalRelayerFee_filter]
+  or: [VAnchorTotalRelayerFee_filter]
+}
+
+enum VAnchorTotalRelayerFee_orderBy {
+  id
+  fees
+}
+
+type VAnchorTotalValueLocked {
+  id: String!
+  totalValueLocked: BigInt!
+}
+
+type VAnchorTotalValueLockedByToken {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  totalValueLocked: BigInt!
+}
+
+type VAnchorTotalValueLockedByTokenEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  totalValueLocked: BigInt!
+}
+
+input VAnchorTotalValueLockedByTokenEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  totalValueLocked: BigInt
+  totalValueLocked_not: BigInt
+  totalValueLocked_gt: BigInt
+  totalValueLocked_lt: BigInt
+  totalValueLocked_gte: BigInt
+  totalValueLocked_lte: BigInt
+  totalValueLocked_in: [BigInt!]
+  totalValueLocked_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalValueLockedByTokenEvery15Min_filter]
+  or: [VAnchorTotalValueLockedByTokenEvery15Min_filter]
+}
+
+enum VAnchorTotalValueLockedByTokenEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  startInterval
+  endInterval
+  totalValueLocked
+}
+
+input VAnchorTotalValueLockedByToken_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  totalValueLocked: BigInt
+  totalValueLocked_not: BigInt
+  totalValueLocked_gt: BigInt
+  totalValueLocked_lt: BigInt
+  totalValueLocked_gte: BigInt
+  totalValueLocked_lte: BigInt
+  totalValueLocked_in: [BigInt!]
+  totalValueLocked_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalValueLockedByToken_filter]
+  or: [VAnchorTotalValueLockedByToken_filter]
+}
+
+enum VAnchorTotalValueLockedByToken_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  totalValueLocked
+}
+
+type VAnchorTotalValueLockedEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  totalValueLocked: BigInt!
+}
+
+input VAnchorTotalValueLockedEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  totalValueLocked: BigInt
+  totalValueLocked_not: BigInt
+  totalValueLocked_gt: BigInt
+  totalValueLocked_lt: BigInt
+  totalValueLocked_gte: BigInt
+  totalValueLocked_lte: BigInt
+  totalValueLocked_in: [BigInt!]
+  totalValueLocked_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalValueLockedEvery15Min_filter]
+  or: [VAnchorTotalValueLockedEvery15Min_filter]
+}
+
+enum VAnchorTotalValueLockedEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  startInterval
+  endInterval
+  totalValueLocked
+}
+
+input VAnchorTotalValueLocked_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  totalValueLocked: BigInt
+  totalValueLocked_not: BigInt
+  totalValueLocked_gt: BigInt
+  totalValueLocked_lt: BigInt
+  totalValueLocked_gte: BigInt
+  totalValueLocked_lte: BigInt
+  totalValueLocked_in: [BigInt!]
+  totalValueLocked_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalValueLocked_filter]
+  or: [VAnchorTotalValueLocked_filter]
+}
+
+enum VAnchorTotalValueLocked_orderBy {
+  id
+  totalValueLocked
+}
+
+type VAnchorTotalWrappingFee {
+  id: String!
+  fees: BigInt!
+}
+
+type VAnchorTotalWrappingFee15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  fees: BigInt!
+}
+
+input VAnchorTotalWrappingFee15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalWrappingFee15Min_filter]
+  or: [VAnchorTotalWrappingFee15Min_filter]
+}
+
+enum VAnchorTotalWrappingFee15Min_orderBy {
+  id
+  vAnchorAddress
+  startInterval
+  endInterval
+  fees
+}
+
+type VAnchorTotalWrappingFeeByToken {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenSymbol: String!
+  tokenAddress: Bytes!
+  fees: BigInt!
+}
+
+type VAnchorTotalWrappingFeeByTokenEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  fees: BigInt!
+}
+
+input VAnchorTotalWrappingFeeByTokenEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalWrappingFeeByTokenEvery15Min_filter]
+  or: [VAnchorTotalWrappingFeeByTokenEvery15Min_filter]
+}
+
+enum VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  startInterval
+  endInterval
+  fees
+}
+
+input VAnchorTotalWrappingFeeByToken_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalWrappingFeeByToken_filter]
+  or: [VAnchorTotalWrappingFeeByToken_filter]
+}
+
+enum VAnchorTotalWrappingFeeByToken_orderBy {
+  id
+  vAnchorAddress
+  tokenSymbol
+  tokenAddress
+  fees
+}
+
+input VAnchorTotalWrappingFee_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalWrappingFee_filter]
+  or: [VAnchorTotalWrappingFee_filter]
+}
+
+enum VAnchorTotalWrappingFee_orderBy {
+  id
+  fees
+}
+
+type VAnchorTransferLog {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  timestamp: BigInt!
+}
+
+input VAnchorTransferLog_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTransferLog_filter]
+  or: [VAnchorTransferLog_filter]
+}
+
+enum VAnchorTransferLog_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  timestamp
+}
+
+type VAnchorWithdrawal {
+  id: String!
+  withdrawal: BigInt!
+  averageWithdrawal: BigInt!
+  totalCount: BigInt!
+}
+
+type VAnchorWithdrawalByToken {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  withdrawal: BigInt!
+  averageWithdrawal: BigInt!
+  totalCount: BigInt!
+}
+
+type VAnchorWithdrawalByTokenEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  withdrawal: BigInt!
+  averageWithdrawal: BigInt!
+  totalCount: BigInt!
+}
+
+input VAnchorWithdrawalByTokenEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  withdrawal: BigInt
+  withdrawal_not: BigInt
+  withdrawal_gt: BigInt
+  withdrawal_lt: BigInt
+  withdrawal_gte: BigInt
+  withdrawal_lte: BigInt
+  withdrawal_in: [BigInt!]
+  withdrawal_not_in: [BigInt!]
+  averageWithdrawal: BigInt
+  averageWithdrawal_not: BigInt
+  averageWithdrawal_gt: BigInt
+  averageWithdrawal_lt: BigInt
+  averageWithdrawal_gte: BigInt
+  averageWithdrawal_lte: BigInt
+  averageWithdrawal_in: [BigInt!]
+  averageWithdrawal_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorWithdrawalByTokenEvery15Min_filter]
+  or: [VAnchorWithdrawalByTokenEvery15Min_filter]
+}
+
+enum VAnchorWithdrawalByTokenEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  startInterval
+  endInterval
+  withdrawal
+  averageWithdrawal
+  totalCount
+}
+
+input VAnchorWithdrawalByToken_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  withdrawal: BigInt
+  withdrawal_not: BigInt
+  withdrawal_gt: BigInt
+  withdrawal_lt: BigInt
+  withdrawal_gte: BigInt
+  withdrawal_lte: BigInt
+  withdrawal_in: [BigInt!]
+  withdrawal_not_in: [BigInt!]
+  averageWithdrawal: BigInt
+  averageWithdrawal_not: BigInt
+  averageWithdrawal_gt: BigInt
+  averageWithdrawal_lt: BigInt
+  averageWithdrawal_gte: BigInt
+  averageWithdrawal_lte: BigInt
+  averageWithdrawal_in: [BigInt!]
+  averageWithdrawal_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorWithdrawalByToken_filter]
+  or: [VAnchorWithdrawalByToken_filter]
+}
+
+enum VAnchorWithdrawalByToken_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  withdrawal
+  averageWithdrawal
+  totalCount
+}
+
+type VAnchorWithdrawalEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  withdrawal: BigInt!
+  averageWithdrawal: BigInt!
+  totalCount: BigInt!
+}
+
+input VAnchorWithdrawalEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  withdrawal: BigInt
+  withdrawal_not: BigInt
+  withdrawal_gt: BigInt
+  withdrawal_lt: BigInt
+  withdrawal_gte: BigInt
+  withdrawal_lte: BigInt
+  withdrawal_in: [BigInt!]
+  withdrawal_not_in: [BigInt!]
+  averageWithdrawal: BigInt
+  averageWithdrawal_not: BigInt
+  averageWithdrawal_gt: BigInt
+  averageWithdrawal_lt: BigInt
+  averageWithdrawal_gte: BigInt
+  averageWithdrawal_lte: BigInt
+  averageWithdrawal_in: [BigInt!]
+  averageWithdrawal_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorWithdrawalEvery15Min_filter]
+  or: [VAnchorWithdrawalEvery15Min_filter]
+}
+
+enum VAnchorWithdrawalEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  startInterval
+  endInterval
+  withdrawal
+  averageWithdrawal
+  totalCount
+}
+
+type VAnchorWithdrawalLog {
+  id: String!
+  withdrawal: BigInt!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  timestamp: BigInt!
+}
+
+input VAnchorWithdrawalLog_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  withdrawal: BigInt
+  withdrawal_not: BigInt
+  withdrawal_gt: BigInt
+  withdrawal_lt: BigInt
+  withdrawal_gte: BigInt
+  withdrawal_lte: BigInt
+  withdrawal_in: [BigInt!]
+  withdrawal_not_in: [BigInt!]
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorWithdrawalLog_filter]
+  or: [VAnchorWithdrawalLog_filter]
+}
+
+enum VAnchorWithdrawalLog_orderBy {
+  id
+  withdrawal
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  timestamp
+}
+
+input VAnchorWithdrawal_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  withdrawal: BigInt
+  withdrawal_not: BigInt
+  withdrawal_gt: BigInt
+  withdrawal_lt: BigInt
+  withdrawal_gte: BigInt
+  withdrawal_lte: BigInt
+  withdrawal_in: [BigInt!]
+  withdrawal_not_in: [BigInt!]
+  averageWithdrawal: BigInt
+  averageWithdrawal_not: BigInt
+  averageWithdrawal_gt: BigInt
+  averageWithdrawal_lt: BigInt
+  averageWithdrawal_gte: BigInt
+  averageWithdrawal_lte: BigInt
+  averageWithdrawal_in: [BigInt!]
+  averageWithdrawal_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorWithdrawal_filter]
+  or: [VAnchorWithdrawal_filter]
+}
+
+enum VAnchorWithdrawal_orderBy {
+  id
+  withdrawal
+  averageWithdrawal
+  totalCount
+}
+
+type WrappingEventLog {
+  id: String!
+  sender: Bytes!
+  recipient: Bytes!
+  tokenAddress: Bytes!
+  wrappingFee: BigInt!
+  afterFeeAmount: BigInt!
+  timestamp: BigInt!
+}
+
+input WrappingEventLog_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  sender: Bytes
+  sender_not: Bytes
+  sender_gt: Bytes
+  sender_lt: Bytes
+  sender_gte: Bytes
+  sender_lte: Bytes
+  sender_in: [Bytes!]
+  sender_not_in: [Bytes!]
+  sender_contains: Bytes
+  sender_not_contains: Bytes
+  recipient: Bytes
+  recipient_not: Bytes
+  recipient_gt: Bytes
+  recipient_lt: Bytes
+  recipient_gte: Bytes
+  recipient_lte: Bytes
+  recipient_in: [Bytes!]
+  recipient_not_in: [Bytes!]
+  recipient_contains: Bytes
+  recipient_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  wrappingFee: BigInt
+  wrappingFee_not: BigInt
+  wrappingFee_gt: BigInt
+  wrappingFee_lt: BigInt
+  wrappingFee_gte: BigInt
+  wrappingFee_lte: BigInt
+  wrappingFee_in: [BigInt!]
+  wrappingFee_not_in: [BigInt!]
+  afterFeeAmount: BigInt
+  afterFeeAmount_not: BigInt
+  afterFeeAmount_gt: BigInt
+  afterFeeAmount_lt: BigInt
+  afterFeeAmount_gte: BigInt
+  afterFeeAmount_lte: BigInt
+  afterFeeAmount_in: [BigInt!]
+  afterFeeAmount_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [WrappingEventLog_filter]
+  or: [WrappingEventLog_filter]
+}
+
+enum WrappingEventLog_orderBy {
+  id
+  sender
+  recipient
+  tokenAddress
+  wrappingFee
+  afterFeeAmount
+  timestamp
+}
+
+type _Block_ {
+  """The hash of the block"""
+  hash: Bytes
+  """The block number"""
+  number: Int!
+  """Integer representation of the timestamp stored in blocks for the chain"""
+  timestamp: Int
+}
+
+"""The type for the top-level _meta field"""
+type _Meta_ {
+  """
+  Information about a specific subgraph block. The hash of the block
+  will be null if the _meta field has a block constraint that asks for
+  a block number. It will be filled if the _meta field has no block constraint
+  and therefore asks for the latest  block
+  
+  """
+  block: _Block_!
+  """The deployment ID"""
+  deployment: String!
+  """If `true`, the subgraph encountered indexing errors at some past block"""
+  hasIndexingErrors: Boolean!
+}
+
+enum _SubgraphErrorPolicy_ {
+  """Data will be returned even if the subgraph has indexing errors"""
+  allow
+  """
+  If the subgraph has indexing errors, data will be omitted. The default.
+  """
+  deny
+}

--- a/packages/vanchor-client/.graphclient/sources/vanchor/schema.graphql
+++ b/packages/vanchor-client/.graphclient/sources/vanchor/schema.graphql
@@ -1,0 +1,5215 @@
+schema {
+  query: Query
+  subscription: Subscription
+}
+
+"Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive."
+directive @entity on OBJECT
+
+"Defined a Subgraph ID for an object type"
+directive @subgraphId(id: String!) on OBJECT
+
+"creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API."
+directive @derivedFrom(field: String!) on FIELD_DEFINITION
+
+scalar BigDecimal
+
+scalar BigInt
+
+input BlockChangedFilter {
+  number_gte: Int!
+}
+
+input Block_height {
+  hash: Bytes
+  number: Int
+  number_gte: Int
+}
+
+scalar Bytes
+
+type EdgeAddition {
+  id: Bytes!
+  chainID: BigInt!
+  latestLeafIndex: BigInt!
+  merkleRoot: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+input EdgeAddition_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  chainID: BigInt
+  chainID_not: BigInt
+  chainID_gt: BigInt
+  chainID_lt: BigInt
+  chainID_gte: BigInt
+  chainID_lte: BigInt
+  chainID_in: [BigInt!]
+  chainID_not_in: [BigInt!]
+  latestLeafIndex: BigInt
+  latestLeafIndex_not: BigInt
+  latestLeafIndex_gt: BigInt
+  latestLeafIndex_lt: BigInt
+  latestLeafIndex_gte: BigInt
+  latestLeafIndex_lte: BigInt
+  latestLeafIndex_in: [BigInt!]
+  latestLeafIndex_not_in: [BigInt!]
+  merkleRoot: BigInt
+  merkleRoot_not: BigInt
+  merkleRoot_gt: BigInt
+  merkleRoot_lt: BigInt
+  merkleRoot_gte: BigInt
+  merkleRoot_lte: BigInt
+  merkleRoot_in: [BigInt!]
+  merkleRoot_not_in: [BigInt!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [EdgeAddition_filter]
+  or: [EdgeAddition_filter]
+}
+
+enum EdgeAddition_orderBy {
+  id
+  chainID
+  latestLeafIndex
+  merkleRoot
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+type EdgeUpdate {
+  id: Bytes!
+  chainID: BigInt!
+  latestLeafIndex: BigInt!
+  merkleRoot: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+input EdgeUpdate_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  chainID: BigInt
+  chainID_not: BigInt
+  chainID_gt: BigInt
+  chainID_lt: BigInt
+  chainID_gte: BigInt
+  chainID_lte: BigInt
+  chainID_in: [BigInt!]
+  chainID_not_in: [BigInt!]
+  latestLeafIndex: BigInt
+  latestLeafIndex_not: BigInt
+  latestLeafIndex_gt: BigInt
+  latestLeafIndex_lt: BigInt
+  latestLeafIndex_gte: BigInt
+  latestLeafIndex_lte: BigInt
+  latestLeafIndex_in: [BigInt!]
+  latestLeafIndex_not_in: [BigInt!]
+  merkleRoot: BigInt
+  merkleRoot_not: BigInt
+  merkleRoot_gt: BigInt
+  merkleRoot_lt: BigInt
+  merkleRoot_gte: BigInt
+  merkleRoot_lte: BigInt
+  merkleRoot_in: [BigInt!]
+  merkleRoot_not_in: [BigInt!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [EdgeUpdate_filter]
+  or: [EdgeUpdate_filter]
+}
+
+enum EdgeUpdate_orderBy {
+  id
+  chainID
+  latestLeafIndex
+  merkleRoot
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+type Encryptions {
+  id: Bytes!
+  encryptedOutput1: Bytes!
+  encryptedOutput2: Bytes!
+}
+
+input Encryptions_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  encryptedOutput1: Bytes
+  encryptedOutput1_not: Bytes
+  encryptedOutput1_gt: Bytes
+  encryptedOutput1_lt: Bytes
+  encryptedOutput1_gte: Bytes
+  encryptedOutput1_lte: Bytes
+  encryptedOutput1_in: [Bytes!]
+  encryptedOutput1_not_in: [Bytes!]
+  encryptedOutput1_contains: Bytes
+  encryptedOutput1_not_contains: Bytes
+  encryptedOutput2: Bytes
+  encryptedOutput2_not: Bytes
+  encryptedOutput2_gt: Bytes
+  encryptedOutput2_lt: Bytes
+  encryptedOutput2_gte: Bytes
+  encryptedOutput2_lte: Bytes
+  encryptedOutput2_in: [Bytes!]
+  encryptedOutput2_not_in: [Bytes!]
+  encryptedOutput2_contains: Bytes
+  encryptedOutput2_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Encryptions_filter]
+  or: [Encryptions_filter]
+}
+
+enum Encryptions_orderBy {
+  id
+  encryptedOutput1
+  encryptedOutput2
+}
+
+type ExternalData {
+  id: Bytes!
+  recipient: Bytes!
+  extAmount: BigInt!
+  relayer: Bytes!
+  fee: BigInt!
+  refund: BigInt!
+  token: String!
+}
+
+input ExternalData_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  recipient: Bytes
+  recipient_not: Bytes
+  recipient_gt: Bytes
+  recipient_lt: Bytes
+  recipient_gte: Bytes
+  recipient_lte: Bytes
+  recipient_in: [Bytes!]
+  recipient_not_in: [Bytes!]
+  recipient_contains: Bytes
+  recipient_not_contains: Bytes
+  extAmount: BigInt
+  extAmount_not: BigInt
+  extAmount_gt: BigInt
+  extAmount_lt: BigInt
+  extAmount_gte: BigInt
+  extAmount_lte: BigInt
+  extAmount_in: [BigInt!]
+  extAmount_not_in: [BigInt!]
+  relayer: Bytes
+  relayer_not: Bytes
+  relayer_gt: Bytes
+  relayer_lt: Bytes
+  relayer_gte: Bytes
+  relayer_lte: Bytes
+  relayer_in: [Bytes!]
+  relayer_not_in: [Bytes!]
+  relayer_contains: Bytes
+  relayer_not_contains: Bytes
+  fee: BigInt
+  fee_not: BigInt
+  fee_gt: BigInt
+  fee_lt: BigInt
+  fee_gte: BigInt
+  fee_lte: BigInt
+  fee_in: [BigInt!]
+  fee_not_in: [BigInt!]
+  refund: BigInt
+  refund_not: BigInt
+  refund_gt: BigInt
+  refund_lt: BigInt
+  refund_gte: BigInt
+  refund_lte: BigInt
+  refund_in: [BigInt!]
+  refund_not_in: [BigInt!]
+  token: String
+  token_not: String
+  token_gt: String
+  token_lt: String
+  token_gte: String
+  token_lte: String
+  token_in: [String!]
+  token_not_in: [String!]
+  token_contains: String
+  token_contains_nocase: String
+  token_not_contains: String
+  token_not_contains_nocase: String
+  token_starts_with: String
+  token_starts_with_nocase: String
+  token_not_starts_with: String
+  token_not_starts_with_nocase: String
+  token_ends_with: String
+  token_ends_with_nocase: String
+  token_not_ends_with: String
+  token_not_ends_with_nocase: String
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ExternalData_filter]
+  or: [ExternalData_filter]
+}
+
+enum ExternalData_orderBy {
+  id
+  recipient
+  extAmount
+  relayer
+  fee
+  refund
+  token
+}
+
+type Insertion {
+  id: Bytes!
+  commitment: BigInt!
+  leafIndex: BigInt!
+  timestamp: BigInt!
+  newMerkleRoot: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+input Insertion_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  commitment: BigInt
+  commitment_not: BigInt
+  commitment_gt: BigInt
+  commitment_lt: BigInt
+  commitment_gte: BigInt
+  commitment_lte: BigInt
+  commitment_in: [BigInt!]
+  commitment_not_in: [BigInt!]
+  leafIndex: BigInt
+  leafIndex_not: BigInt
+  leafIndex_gt: BigInt
+  leafIndex_lt: BigInt
+  leafIndex_gte: BigInt
+  leafIndex_lte: BigInt
+  leafIndex_in: [BigInt!]
+  leafIndex_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  newMerkleRoot: BigInt
+  newMerkleRoot_not: BigInt
+  newMerkleRoot_gt: BigInt
+  newMerkleRoot_lt: BigInt
+  newMerkleRoot_gte: BigInt
+  newMerkleRoot_lte: BigInt
+  newMerkleRoot_in: [BigInt!]
+  newMerkleRoot_not_in: [BigInt!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Insertion_filter]
+  or: [Insertion_filter]
+}
+
+enum Insertion_orderBy {
+  id
+  commitment
+  leafIndex
+  timestamp
+  newMerkleRoot
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+type NewCommitment {
+  id: Bytes!
+  commitment: BigInt!
+  subTreeIndex: BigInt!
+  leafIndex: BigInt!
+  encryptedOutput: Bytes!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+input NewCommitment_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  commitment: BigInt
+  commitment_not: BigInt
+  commitment_gt: BigInt
+  commitment_lt: BigInt
+  commitment_gte: BigInt
+  commitment_lte: BigInt
+  commitment_in: [BigInt!]
+  commitment_not_in: [BigInt!]
+  subTreeIndex: BigInt
+  subTreeIndex_not: BigInt
+  subTreeIndex_gt: BigInt
+  subTreeIndex_lt: BigInt
+  subTreeIndex_gte: BigInt
+  subTreeIndex_lte: BigInt
+  subTreeIndex_in: [BigInt!]
+  subTreeIndex_not_in: [BigInt!]
+  leafIndex: BigInt
+  leafIndex_not: BigInt
+  leafIndex_gt: BigInt
+  leafIndex_lt: BigInt
+  leafIndex_gte: BigInt
+  leafIndex_lte: BigInt
+  leafIndex_in: [BigInt!]
+  leafIndex_not_in: [BigInt!]
+  encryptedOutput: Bytes
+  encryptedOutput_not: Bytes
+  encryptedOutput_gt: Bytes
+  encryptedOutput_lt: Bytes
+  encryptedOutput_gte: Bytes
+  encryptedOutput_lte: Bytes
+  encryptedOutput_in: [Bytes!]
+  encryptedOutput_not_in: [Bytes!]
+  encryptedOutput_contains: Bytes
+  encryptedOutput_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NewCommitment_filter]
+  or: [NewCommitment_filter]
+}
+
+enum NewCommitment_orderBy {
+  id
+  commitment
+  subTreeIndex
+  leafIndex
+  encryptedOutput
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+type NewNullifier {
+  id: Bytes!
+  nullifier: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+input NewNullifier_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  nullifier: BigInt
+  nullifier_not: BigInt
+  nullifier_gt: BigInt
+  nullifier_lt: BigInt
+  nullifier_gte: BigInt
+  nullifier_lte: BigInt
+  nullifier_in: [BigInt!]
+  nullifier_not_in: [BigInt!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NewNullifier_filter]
+  or: [NewNullifier_filter]
+}
+
+enum NewNullifier_orderBy {
+  id
+  nullifier
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+"""Defines the order direction, either ascending or descending"""
+enum OrderDirection {
+  asc
+  desc
+}
+
+type PublicInputs {
+  id: Bytes!
+  roots: Bytes!
+  extensionRoots: Bytes!
+  inputNullifiers: [BigInt!]!
+  outputCommitments: [BigInt!]!
+  publicAmount: BigInt!
+  extDataHash: BigInt!
+}
+
+input PublicInputs_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  roots: Bytes
+  roots_not: Bytes
+  roots_gt: Bytes
+  roots_lt: Bytes
+  roots_gte: Bytes
+  roots_lte: Bytes
+  roots_in: [Bytes!]
+  roots_not_in: [Bytes!]
+  roots_contains: Bytes
+  roots_not_contains: Bytes
+  extensionRoots: Bytes
+  extensionRoots_not: Bytes
+  extensionRoots_gt: Bytes
+  extensionRoots_lt: Bytes
+  extensionRoots_gte: Bytes
+  extensionRoots_lte: Bytes
+  extensionRoots_in: [Bytes!]
+  extensionRoots_not_in: [Bytes!]
+  extensionRoots_contains: Bytes
+  extensionRoots_not_contains: Bytes
+  inputNullifiers: [BigInt!]
+  inputNullifiers_not: [BigInt!]
+  inputNullifiers_contains: [BigInt!]
+  inputNullifiers_contains_nocase: [BigInt!]
+  inputNullifiers_not_contains: [BigInt!]
+  inputNullifiers_not_contains_nocase: [BigInt!]
+  outputCommitments: [BigInt!]
+  outputCommitments_not: [BigInt!]
+  outputCommitments_contains: [BigInt!]
+  outputCommitments_contains_nocase: [BigInt!]
+  outputCommitments_not_contains: [BigInt!]
+  outputCommitments_not_contains_nocase: [BigInt!]
+  publicAmount: BigInt
+  publicAmount_not: BigInt
+  publicAmount_gt: BigInt
+  publicAmount_lt: BigInt
+  publicAmount_gte: BigInt
+  publicAmount_lte: BigInt
+  publicAmount_in: [BigInt!]
+  publicAmount_not_in: [BigInt!]
+  extDataHash: BigInt
+  extDataHash_not: BigInt
+  extDataHash_gt: BigInt
+  extDataHash_lt: BigInt
+  extDataHash_gte: BigInt
+  extDataHash_lte: BigInt
+  extDataHash_in: [BigInt!]
+  extDataHash_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [PublicInputs_filter]
+  or: [PublicInputs_filter]
+}
+
+enum PublicInputs_orderBy {
+  id
+  roots
+  extensionRoots
+  inputNullifiers
+  outputCommitments
+  publicAmount
+  extDataHash
+}
+
+type PublicKey {
+  id: Bytes!
+  owner: Bytes!
+  key: Bytes!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+input PublicKey_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  owner: Bytes
+  owner_not: Bytes
+  owner_gt: Bytes
+  owner_lt: Bytes
+  owner_gte: Bytes
+  owner_lte: Bytes
+  owner_in: [Bytes!]
+  owner_not_in: [Bytes!]
+  owner_contains: Bytes
+  owner_not_contains: Bytes
+  key: Bytes
+  key_not: Bytes
+  key_gt: Bytes
+  key_lt: Bytes
+  key_gte: Bytes
+  key_lte: Bytes
+  key_in: [Bytes!]
+  key_not_in: [Bytes!]
+  key_contains: Bytes
+  key_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [PublicKey_filter]
+  or: [PublicKey_filter]
+}
+
+enum PublicKey_orderBy {
+  id
+  owner
+  key
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+type Query {
+  edgeAddition(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EdgeAddition
+  edgeAdditions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EdgeAddition_orderBy
+    orderDirection: OrderDirection
+    where: EdgeAddition_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EdgeAddition!]!
+  edgeUpdate(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EdgeUpdate
+  edgeUpdates(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EdgeUpdate_orderBy
+    orderDirection: OrderDirection
+    where: EdgeUpdate_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EdgeUpdate!]!
+  insertion(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Insertion
+  insertions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Insertion_orderBy
+    orderDirection: OrderDirection
+    where: Insertion_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Insertion!]!
+  newCommitment(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NewCommitment
+  newCommitments(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: NewCommitment_orderBy
+    orderDirection: OrderDirection
+    where: NewCommitment_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [NewCommitment!]!
+  newNullifier(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NewNullifier
+  newNullifiers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: NewNullifier_orderBy
+    orderDirection: OrderDirection
+    where: NewNullifier_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [NewNullifier!]!
+  publicKey(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): PublicKey
+  publicKeys(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: PublicKey_orderBy
+    orderDirection: OrderDirection
+    where: PublicKey_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [PublicKey!]!
+  token(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Token
+  tokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Token_orderBy
+    orderDirection: OrderDirection
+    where: Token_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Token!]!
+  externalData(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ExternalData
+  externalDatas(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ExternalData_orderBy
+    orderDirection: OrderDirection
+    where: ExternalData_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ExternalData!]!
+  publicInputs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: PublicInputs_orderBy
+    orderDirection: OrderDirection
+    where: PublicInputs_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [PublicInputs!]!
+  encryptions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Encryptions_orderBy
+    orderDirection: OrderDirection
+    where: Encryptions_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Encryptions!]!
+  shieldedTransaction(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ShieldedTransaction
+  shieldedTransactions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ShieldedTransaction_orderBy
+    orderDirection: OrderDirection
+    where: ShieldedTransaction_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ShieldedTransaction!]!
+  vanchorTotalValueLocked(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLocked
+  vanchorTotalValueLockeds(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLocked_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLocked_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLocked!]!
+  vanchorTotalValueLockedByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLockedByToken
+  vanchorTotalValueLockedByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLockedByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLockedByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLockedByToken!]!
+  vanchorTotalValueLockedEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLockedEvery15Min
+  vanchorTotalValueLockedEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLockedEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLockedEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLockedEvery15Min!]!
+  vanchorTotalValueLockedByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLockedByTokenEvery15Min
+  vanchorTotalValueLockedByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLockedByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLockedByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLockedByTokenEvery15Min!]!
+  vanchorTotalRelayerFee(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFee
+  vanchorTotalRelayerFees(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFee_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFee_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFee!]!
+  vanchorTotalRelayerFeeByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFeeByToken
+  vanchorTotalRelayerFeeByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFeeByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFeeByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFeeByToken!]!
+  vanchorTotalRelayerFee15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFee15Min
+  vanchorTotalRelayerFee15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFee15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFee15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFee15Min!]!
+  vanchorTotalRelayerFeeByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFeeByTokenEvery15Min
+  vanchorTotalRelayerFeeByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFeeByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFeeByTokenEvery15Min!]!
+  vanchorTotalWrappingFee(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFee
+  vanchorTotalWrappingFees(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFee_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFee_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFee!]!
+  vanchorTotalWrappingFeeByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFeeByToken
+  vanchorTotalWrappingFeeByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFeeByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFeeByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFeeByToken!]!
+  vanchorTotalWrappingFee15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFee15Min
+  vanchorTotalWrappingFee15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFee15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFee15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFee15Min!]!
+  vanchorTotalWrappingFeeByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFeeByTokenEvery15Min
+  vanchorTotalWrappingFeeByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFeeByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFeeByTokenEvery15Min!]!
+  wrappingEventLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): WrappingEventLog
+  wrappingEventLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: WrappingEventLog_orderBy
+    orderDirection: OrderDirection
+    where: WrappingEventLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [WrappingEventLog!]!
+  unwrappingEventLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): UnwrappingEventLog
+  unwrappingEventLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: UnwrappingEventLog_orderBy
+    orderDirection: OrderDirection
+    where: UnwrappingEventLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [UnwrappingEventLog!]!
+  vanchorWithdrawalLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalLog
+  vanchorWithdrawalLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalLog_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalLog!]!
+  vanchorWithdrawal(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawal
+  vanchorWithdrawals(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawal_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawal_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawal!]!
+  vanchorWithdrawalByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalByToken
+  vanchorWithdrawalByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalByToken!]!
+  vanchorWithdrawalEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalEvery15Min
+  vanchorWithdrawalEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalEvery15Min!]!
+  vanchorWithdrawalByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalByTokenEvery15Min
+  vanchorWithdrawalByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalByTokenEvery15Min!]!
+  vanchorDeposit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDeposit
+  vanchorDeposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDeposit_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDeposit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDeposit!]!
+  vanchorDepositByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositByToken
+  vanchorDepositByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositByToken!]!
+  vanchorDepositEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositEvery15Min
+  vanchorDepositEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositEvery15Min!]!
+  vanchorDepositByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositByTokenEvery15Min
+  vanchorDepositByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositByTokenEvery15Min!]!
+  vanchorDepositLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositLog
+  vanchorDepositLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositLog_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositLog!]!
+  vanchorTransferLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTransferLog
+  vanchorTransferLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTransferLog_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTransferLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTransferLog!]!
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
+}
+
+type ShieldedTransaction {
+  id: Bytes!
+  vanchor: Bytes!
+  sender: Bytes!
+  value: BigInt!
+  proof: Bytes!
+  auxPublicInputs: Bytes!
+  externalData: ExternalData!
+  publicInputs: PublicInputs!
+  encryptions: Encryptions!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+input ShieldedTransaction_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  vanchor: Bytes
+  vanchor_not: Bytes
+  vanchor_gt: Bytes
+  vanchor_lt: Bytes
+  vanchor_gte: Bytes
+  vanchor_lte: Bytes
+  vanchor_in: [Bytes!]
+  vanchor_not_in: [Bytes!]
+  vanchor_contains: Bytes
+  vanchor_not_contains: Bytes
+  sender: Bytes
+  sender_not: Bytes
+  sender_gt: Bytes
+  sender_lt: Bytes
+  sender_gte: Bytes
+  sender_lte: Bytes
+  sender_in: [Bytes!]
+  sender_not_in: [Bytes!]
+  sender_contains: Bytes
+  sender_not_contains: Bytes
+  value: BigInt
+  value_not: BigInt
+  value_gt: BigInt
+  value_lt: BigInt
+  value_gte: BigInt
+  value_lte: BigInt
+  value_in: [BigInt!]
+  value_not_in: [BigInt!]
+  proof: Bytes
+  proof_not: Bytes
+  proof_gt: Bytes
+  proof_lt: Bytes
+  proof_gte: Bytes
+  proof_lte: Bytes
+  proof_in: [Bytes!]
+  proof_not_in: [Bytes!]
+  proof_contains: Bytes
+  proof_not_contains: Bytes
+  auxPublicInputs: Bytes
+  auxPublicInputs_not: Bytes
+  auxPublicInputs_gt: Bytes
+  auxPublicInputs_lt: Bytes
+  auxPublicInputs_gte: Bytes
+  auxPublicInputs_lte: Bytes
+  auxPublicInputs_in: [Bytes!]
+  auxPublicInputs_not_in: [Bytes!]
+  auxPublicInputs_contains: Bytes
+  auxPublicInputs_not_contains: Bytes
+  externalData: String
+  externalData_not: String
+  externalData_gt: String
+  externalData_lt: String
+  externalData_gte: String
+  externalData_lte: String
+  externalData_in: [String!]
+  externalData_not_in: [String!]
+  externalData_contains: String
+  externalData_contains_nocase: String
+  externalData_not_contains: String
+  externalData_not_contains_nocase: String
+  externalData_starts_with: String
+  externalData_starts_with_nocase: String
+  externalData_not_starts_with: String
+  externalData_not_starts_with_nocase: String
+  externalData_ends_with: String
+  externalData_ends_with_nocase: String
+  externalData_not_ends_with: String
+  externalData_not_ends_with_nocase: String
+  externalData_: ExternalData_filter
+  publicInputs: String
+  publicInputs_not: String
+  publicInputs_gt: String
+  publicInputs_lt: String
+  publicInputs_gte: String
+  publicInputs_lte: String
+  publicInputs_in: [String!]
+  publicInputs_not_in: [String!]
+  publicInputs_contains: String
+  publicInputs_contains_nocase: String
+  publicInputs_not_contains: String
+  publicInputs_not_contains_nocase: String
+  publicInputs_starts_with: String
+  publicInputs_starts_with_nocase: String
+  publicInputs_not_starts_with: String
+  publicInputs_not_starts_with_nocase: String
+  publicInputs_ends_with: String
+  publicInputs_ends_with_nocase: String
+  publicInputs_not_ends_with: String
+  publicInputs_not_ends_with_nocase: String
+  publicInputs_: PublicInputs_filter
+  encryptions: String
+  encryptions_not: String
+  encryptions_gt: String
+  encryptions_lt: String
+  encryptions_gte: String
+  encryptions_lte: String
+  encryptions_in: [String!]
+  encryptions_not_in: [String!]
+  encryptions_contains: String
+  encryptions_contains_nocase: String
+  encryptions_not_contains: String
+  encryptions_not_contains_nocase: String
+  encryptions_starts_with: String
+  encryptions_starts_with_nocase: String
+  encryptions_not_starts_with: String
+  encryptions_not_starts_with_nocase: String
+  encryptions_ends_with: String
+  encryptions_ends_with_nocase: String
+  encryptions_not_ends_with: String
+  encryptions_not_ends_with_nocase: String
+  encryptions_: Encryptions_filter
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  blockTimestamp: BigInt
+  blockTimestamp_not: BigInt
+  blockTimestamp_gt: BigInt
+  blockTimestamp_lt: BigInt
+  blockTimestamp_gte: BigInt
+  blockTimestamp_lte: BigInt
+  blockTimestamp_in: [BigInt!]
+  blockTimestamp_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ShieldedTransaction_filter]
+  or: [ShieldedTransaction_filter]
+}
+
+enum ShieldedTransaction_orderBy {
+  id
+  vanchor
+  sender
+  value
+  proof
+  auxPublicInputs
+  externalData
+  externalData__id
+  externalData__recipient
+  externalData__extAmount
+  externalData__relayer
+  externalData__fee
+  externalData__refund
+  externalData__token
+  publicInputs
+  publicInputs__id
+  publicInputs__roots
+  publicInputs__extensionRoots
+  publicInputs__publicAmount
+  publicInputs__extDataHash
+  encryptions
+  encryptions__id
+  encryptions__encryptedOutput1
+  encryptions__encryptedOutput2
+  blockNumber
+  blockTimestamp
+  transactionHash
+}
+
+type Subscription {
+  edgeAddition(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EdgeAddition
+  edgeAdditions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EdgeAddition_orderBy
+    orderDirection: OrderDirection
+    where: EdgeAddition_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EdgeAddition!]!
+  edgeUpdate(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EdgeUpdate
+  edgeUpdates(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EdgeUpdate_orderBy
+    orderDirection: OrderDirection
+    where: EdgeUpdate_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EdgeUpdate!]!
+  insertion(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Insertion
+  insertions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Insertion_orderBy
+    orderDirection: OrderDirection
+    where: Insertion_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Insertion!]!
+  newCommitment(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NewCommitment
+  newCommitments(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: NewCommitment_orderBy
+    orderDirection: OrderDirection
+    where: NewCommitment_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [NewCommitment!]!
+  newNullifier(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NewNullifier
+  newNullifiers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: NewNullifier_orderBy
+    orderDirection: OrderDirection
+    where: NewNullifier_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [NewNullifier!]!
+  publicKey(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): PublicKey
+  publicKeys(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: PublicKey_orderBy
+    orderDirection: OrderDirection
+    where: PublicKey_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [PublicKey!]!
+  token(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Token
+  tokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Token_orderBy
+    orderDirection: OrderDirection
+    where: Token_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Token!]!
+  externalData(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ExternalData
+  externalDatas(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ExternalData_orderBy
+    orderDirection: OrderDirection
+    where: ExternalData_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ExternalData!]!
+  publicInputs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: PublicInputs_orderBy
+    orderDirection: OrderDirection
+    where: PublicInputs_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [PublicInputs!]!
+  encryptions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Encryptions_orderBy
+    orderDirection: OrderDirection
+    where: Encryptions_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Encryptions!]!
+  shieldedTransaction(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ShieldedTransaction
+  shieldedTransactions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ShieldedTransaction_orderBy
+    orderDirection: OrderDirection
+    where: ShieldedTransaction_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ShieldedTransaction!]!
+  vanchorTotalValueLocked(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLocked
+  vanchorTotalValueLockeds(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLocked_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLocked_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLocked!]!
+  vanchorTotalValueLockedByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLockedByToken
+  vanchorTotalValueLockedByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLockedByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLockedByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLockedByToken!]!
+  vanchorTotalValueLockedEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLockedEvery15Min
+  vanchorTotalValueLockedEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLockedEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLockedEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLockedEvery15Min!]!
+  vanchorTotalValueLockedByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalValueLockedByTokenEvery15Min
+  vanchorTotalValueLockedByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalValueLockedByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalValueLockedByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalValueLockedByTokenEvery15Min!]!
+  vanchorTotalRelayerFee(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFee
+  vanchorTotalRelayerFees(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFee_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFee_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFee!]!
+  vanchorTotalRelayerFeeByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFeeByToken
+  vanchorTotalRelayerFeeByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFeeByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFeeByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFeeByToken!]!
+  vanchorTotalRelayerFee15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFee15Min
+  vanchorTotalRelayerFee15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFee15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFee15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFee15Min!]!
+  vanchorTotalRelayerFeeByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalRelayerFeeByTokenEvery15Min
+  vanchorTotalRelayerFeeByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalRelayerFeeByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalRelayerFeeByTokenEvery15Min!]!
+  vanchorTotalWrappingFee(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFee
+  vanchorTotalWrappingFees(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFee_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFee_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFee!]!
+  vanchorTotalWrappingFeeByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFeeByToken
+  vanchorTotalWrappingFeeByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFeeByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFeeByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFeeByToken!]!
+  vanchorTotalWrappingFee15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFee15Min
+  vanchorTotalWrappingFee15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFee15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFee15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFee15Min!]!
+  vanchorTotalWrappingFeeByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTotalWrappingFeeByTokenEvery15Min
+  vanchorTotalWrappingFeeByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTotalWrappingFeeByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTotalWrappingFeeByTokenEvery15Min!]!
+  wrappingEventLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): WrappingEventLog
+  wrappingEventLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: WrappingEventLog_orderBy
+    orderDirection: OrderDirection
+    where: WrappingEventLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [WrappingEventLog!]!
+  unwrappingEventLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): UnwrappingEventLog
+  unwrappingEventLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: UnwrappingEventLog_orderBy
+    orderDirection: OrderDirection
+    where: UnwrappingEventLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [UnwrappingEventLog!]!
+  vanchorWithdrawalLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalLog
+  vanchorWithdrawalLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalLog_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalLog!]!
+  vanchorWithdrawal(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawal
+  vanchorWithdrawals(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawal_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawal_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawal!]!
+  vanchorWithdrawalByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalByToken
+  vanchorWithdrawalByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalByToken!]!
+  vanchorWithdrawalEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalEvery15Min
+  vanchorWithdrawalEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalEvery15Min!]!
+  vanchorWithdrawalByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorWithdrawalByTokenEvery15Min
+  vanchorWithdrawalByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorWithdrawalByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorWithdrawalByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorWithdrawalByTokenEvery15Min!]!
+  vanchorDeposit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDeposit
+  vanchorDeposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDeposit_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDeposit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDeposit!]!
+  vanchorDepositByToken(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositByToken
+  vanchorDepositByTokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositByToken_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositByToken_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositByToken!]!
+  vanchorDepositEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositEvery15Min
+  vanchorDepositEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositEvery15Min!]!
+  vanchorDepositByTokenEvery15Min(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositByTokenEvery15Min
+  vanchorDepositByTokenEvery15Mins(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositByTokenEvery15Min_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositByTokenEvery15Min_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositByTokenEvery15Min!]!
+  vanchorDepositLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorDepositLog
+  vanchorDepositLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorDepositLog_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorDepositLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorDepositLog!]!
+  vanchorTransferLog(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VAnchorTransferLog
+  vanchorTransferLogs(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: VAnchorTransferLog_orderBy
+    orderDirection: OrderDirection
+    where: VAnchorTransferLog_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [VAnchorTransferLog!]!
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
+}
+
+type Token {
+  id: Bytes!
+  address: Bytes!
+  decimals: Int!
+  name: String!
+  symbol: String!
+}
+
+input Token_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  address: Bytes
+  address_not: Bytes
+  address_gt: Bytes
+  address_lt: Bytes
+  address_gte: Bytes
+  address_lte: Bytes
+  address_in: [Bytes!]
+  address_not_in: [Bytes!]
+  address_contains: Bytes
+  address_not_contains: Bytes
+  decimals: Int
+  decimals_not: Int
+  decimals_gt: Int
+  decimals_lt: Int
+  decimals_gte: Int
+  decimals_lte: Int
+  decimals_in: [Int!]
+  decimals_not_in: [Int!]
+  name: String
+  name_not: String
+  name_gt: String
+  name_lt: String
+  name_gte: String
+  name_lte: String
+  name_in: [String!]
+  name_not_in: [String!]
+  name_contains: String
+  name_contains_nocase: String
+  name_not_contains: String
+  name_not_contains_nocase: String
+  name_starts_with: String
+  name_starts_with_nocase: String
+  name_not_starts_with: String
+  name_not_starts_with_nocase: String
+  name_ends_with: String
+  name_ends_with_nocase: String
+  name_not_ends_with: String
+  name_not_ends_with_nocase: String
+  symbol: String
+  symbol_not: String
+  symbol_gt: String
+  symbol_lt: String
+  symbol_gte: String
+  symbol_lte: String
+  symbol_in: [String!]
+  symbol_not_in: [String!]
+  symbol_contains: String
+  symbol_contains_nocase: String
+  symbol_not_contains: String
+  symbol_not_contains_nocase: String
+  symbol_starts_with: String
+  symbol_starts_with_nocase: String
+  symbol_not_starts_with: String
+  symbol_not_starts_with_nocase: String
+  symbol_ends_with: String
+  symbol_ends_with_nocase: String
+  symbol_not_ends_with: String
+  symbol_not_ends_with_nocase: String
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Token_filter]
+  or: [Token_filter]
+}
+
+enum Token_orderBy {
+  id
+  address
+  decimals
+  name
+  symbol
+}
+
+type UnwrappingEventLog {
+  id: String!
+  sender: Bytes!
+  recipient: Bytes!
+  tokenAddress: Bytes!
+  amount: BigInt!
+  timestamp: BigInt!
+}
+
+input UnwrappingEventLog_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  sender: Bytes
+  sender_not: Bytes
+  sender_gt: Bytes
+  sender_lt: Bytes
+  sender_gte: Bytes
+  sender_lte: Bytes
+  sender_in: [Bytes!]
+  sender_not_in: [Bytes!]
+  sender_contains: Bytes
+  sender_not_contains: Bytes
+  recipient: Bytes
+  recipient_not: Bytes
+  recipient_gt: Bytes
+  recipient_lt: Bytes
+  recipient_gte: Bytes
+  recipient_lte: Bytes
+  recipient_in: [Bytes!]
+  recipient_not_in: [Bytes!]
+  recipient_contains: Bytes
+  recipient_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  amount: BigInt
+  amount_not: BigInt
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  amount_in: [BigInt!]
+  amount_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [UnwrappingEventLog_filter]
+  or: [UnwrappingEventLog_filter]
+}
+
+enum UnwrappingEventLog_orderBy {
+  id
+  sender
+  recipient
+  tokenAddress
+  amount
+  timestamp
+}
+
+type VAnchorDeposit {
+  id: String!
+  deposit: BigInt!
+  averageDeposit: BigInt!
+  totalCount: BigInt!
+}
+
+type VAnchorDepositByToken {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  deposit: BigInt!
+  averageDeposit: BigInt!
+  totalCount: BigInt!
+}
+
+type VAnchorDepositByTokenEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  deposit: BigInt!
+  averageDeposit: BigInt!
+  totalCount: BigInt!
+}
+
+input VAnchorDepositByTokenEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  deposit: BigInt
+  deposit_not: BigInt
+  deposit_gt: BigInt
+  deposit_lt: BigInt
+  deposit_gte: BigInt
+  deposit_lte: BigInt
+  deposit_in: [BigInt!]
+  deposit_not_in: [BigInt!]
+  averageDeposit: BigInt
+  averageDeposit_not: BigInt
+  averageDeposit_gt: BigInt
+  averageDeposit_lt: BigInt
+  averageDeposit_gte: BigInt
+  averageDeposit_lte: BigInt
+  averageDeposit_in: [BigInt!]
+  averageDeposit_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorDepositByTokenEvery15Min_filter]
+  or: [VAnchorDepositByTokenEvery15Min_filter]
+}
+
+enum VAnchorDepositByTokenEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  startInterval
+  endInterval
+  deposit
+  averageDeposit
+  totalCount
+}
+
+input VAnchorDepositByToken_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  deposit: BigInt
+  deposit_not: BigInt
+  deposit_gt: BigInt
+  deposit_lt: BigInt
+  deposit_gte: BigInt
+  deposit_lte: BigInt
+  deposit_in: [BigInt!]
+  deposit_not_in: [BigInt!]
+  averageDeposit: BigInt
+  averageDeposit_not: BigInt
+  averageDeposit_gt: BigInt
+  averageDeposit_lt: BigInt
+  averageDeposit_gte: BigInt
+  averageDeposit_lte: BigInt
+  averageDeposit_in: [BigInt!]
+  averageDeposit_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorDepositByToken_filter]
+  or: [VAnchorDepositByToken_filter]
+}
+
+enum VAnchorDepositByToken_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  deposit
+  averageDeposit
+  totalCount
+}
+
+type VAnchorDepositEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  deposit: BigInt!
+  averageDeposit: BigInt!
+  totalCount: BigInt!
+}
+
+input VAnchorDepositEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  deposit: BigInt
+  deposit_not: BigInt
+  deposit_gt: BigInt
+  deposit_lt: BigInt
+  deposit_gte: BigInt
+  deposit_lte: BigInt
+  deposit_in: [BigInt!]
+  deposit_not_in: [BigInt!]
+  averageDeposit: BigInt
+  averageDeposit_not: BigInt
+  averageDeposit_gt: BigInt
+  averageDeposit_lt: BigInt
+  averageDeposit_gte: BigInt
+  averageDeposit_lte: BigInt
+  averageDeposit_in: [BigInt!]
+  averageDeposit_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorDepositEvery15Min_filter]
+  or: [VAnchorDepositEvery15Min_filter]
+}
+
+enum VAnchorDepositEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  startInterval
+  endInterval
+  deposit
+  averageDeposit
+  totalCount
+}
+
+type VAnchorDepositLog {
+  id: String!
+  deposit: BigInt!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  timestamp: BigInt!
+}
+
+input VAnchorDepositLog_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  deposit: BigInt
+  deposit_not: BigInt
+  deposit_gt: BigInt
+  deposit_lt: BigInt
+  deposit_gte: BigInt
+  deposit_lte: BigInt
+  deposit_in: [BigInt!]
+  deposit_not_in: [BigInt!]
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorDepositLog_filter]
+  or: [VAnchorDepositLog_filter]
+}
+
+enum VAnchorDepositLog_orderBy {
+  id
+  deposit
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  timestamp
+}
+
+input VAnchorDeposit_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  deposit: BigInt
+  deposit_not: BigInt
+  deposit_gt: BigInt
+  deposit_lt: BigInt
+  deposit_gte: BigInt
+  deposit_lte: BigInt
+  deposit_in: [BigInt!]
+  deposit_not_in: [BigInt!]
+  averageDeposit: BigInt
+  averageDeposit_not: BigInt
+  averageDeposit_gt: BigInt
+  averageDeposit_lt: BigInt
+  averageDeposit_gte: BigInt
+  averageDeposit_lte: BigInt
+  averageDeposit_in: [BigInt!]
+  averageDeposit_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorDeposit_filter]
+  or: [VAnchorDeposit_filter]
+}
+
+enum VAnchorDeposit_orderBy {
+  id
+  deposit
+  averageDeposit
+  totalCount
+}
+
+type VAnchorTotalRelayerFee {
+  id: String!
+  fees: BigInt!
+}
+
+type VAnchorTotalRelayerFee15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  fees: BigInt!
+}
+
+input VAnchorTotalRelayerFee15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalRelayerFee15Min_filter]
+  or: [VAnchorTotalRelayerFee15Min_filter]
+}
+
+enum VAnchorTotalRelayerFee15Min_orderBy {
+  id
+  vAnchorAddress
+  startInterval
+  endInterval
+  fees
+}
+
+type VAnchorTotalRelayerFeeByToken {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenSymbol: String!
+  tokenAddress: Bytes!
+  fees: BigInt!
+}
+
+type VAnchorTotalRelayerFeeByTokenEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  fees: BigInt!
+}
+
+input VAnchorTotalRelayerFeeByTokenEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalRelayerFeeByTokenEvery15Min_filter]
+  or: [VAnchorTotalRelayerFeeByTokenEvery15Min_filter]
+}
+
+enum VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  startInterval
+  endInterval
+  fees
+}
+
+input VAnchorTotalRelayerFeeByToken_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalRelayerFeeByToken_filter]
+  or: [VAnchorTotalRelayerFeeByToken_filter]
+}
+
+enum VAnchorTotalRelayerFeeByToken_orderBy {
+  id
+  vAnchorAddress
+  tokenSymbol
+  tokenAddress
+  fees
+}
+
+input VAnchorTotalRelayerFee_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalRelayerFee_filter]
+  or: [VAnchorTotalRelayerFee_filter]
+}
+
+enum VAnchorTotalRelayerFee_orderBy {
+  id
+  fees
+}
+
+type VAnchorTotalValueLocked {
+  id: String!
+  totalValueLocked: BigInt!
+}
+
+type VAnchorTotalValueLockedByToken {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  totalValueLocked: BigInt!
+}
+
+type VAnchorTotalValueLockedByTokenEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  totalValueLocked: BigInt!
+}
+
+input VAnchorTotalValueLockedByTokenEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  totalValueLocked: BigInt
+  totalValueLocked_not: BigInt
+  totalValueLocked_gt: BigInt
+  totalValueLocked_lt: BigInt
+  totalValueLocked_gte: BigInt
+  totalValueLocked_lte: BigInt
+  totalValueLocked_in: [BigInt!]
+  totalValueLocked_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalValueLockedByTokenEvery15Min_filter]
+  or: [VAnchorTotalValueLockedByTokenEvery15Min_filter]
+}
+
+enum VAnchorTotalValueLockedByTokenEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  startInterval
+  endInterval
+  totalValueLocked
+}
+
+input VAnchorTotalValueLockedByToken_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  totalValueLocked: BigInt
+  totalValueLocked_not: BigInt
+  totalValueLocked_gt: BigInt
+  totalValueLocked_lt: BigInt
+  totalValueLocked_gte: BigInt
+  totalValueLocked_lte: BigInt
+  totalValueLocked_in: [BigInt!]
+  totalValueLocked_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalValueLockedByToken_filter]
+  or: [VAnchorTotalValueLockedByToken_filter]
+}
+
+enum VAnchorTotalValueLockedByToken_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  totalValueLocked
+}
+
+type VAnchorTotalValueLockedEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  totalValueLocked: BigInt!
+}
+
+input VAnchorTotalValueLockedEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  totalValueLocked: BigInt
+  totalValueLocked_not: BigInt
+  totalValueLocked_gt: BigInt
+  totalValueLocked_lt: BigInt
+  totalValueLocked_gte: BigInt
+  totalValueLocked_lte: BigInt
+  totalValueLocked_in: [BigInt!]
+  totalValueLocked_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalValueLockedEvery15Min_filter]
+  or: [VAnchorTotalValueLockedEvery15Min_filter]
+}
+
+enum VAnchorTotalValueLockedEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  startInterval
+  endInterval
+  totalValueLocked
+}
+
+input VAnchorTotalValueLocked_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  totalValueLocked: BigInt
+  totalValueLocked_not: BigInt
+  totalValueLocked_gt: BigInt
+  totalValueLocked_lt: BigInt
+  totalValueLocked_gte: BigInt
+  totalValueLocked_lte: BigInt
+  totalValueLocked_in: [BigInt!]
+  totalValueLocked_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalValueLocked_filter]
+  or: [VAnchorTotalValueLocked_filter]
+}
+
+enum VAnchorTotalValueLocked_orderBy {
+  id
+  totalValueLocked
+}
+
+type VAnchorTotalWrappingFee {
+  id: String!
+  fees: BigInt!
+}
+
+type VAnchorTotalWrappingFee15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  fees: BigInt!
+}
+
+input VAnchorTotalWrappingFee15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalWrappingFee15Min_filter]
+  or: [VAnchorTotalWrappingFee15Min_filter]
+}
+
+enum VAnchorTotalWrappingFee15Min_orderBy {
+  id
+  vAnchorAddress
+  startInterval
+  endInterval
+  fees
+}
+
+type VAnchorTotalWrappingFeeByToken {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenSymbol: String!
+  tokenAddress: Bytes!
+  fees: BigInt!
+}
+
+type VAnchorTotalWrappingFeeByTokenEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  fees: BigInt!
+}
+
+input VAnchorTotalWrappingFeeByTokenEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalWrappingFeeByTokenEvery15Min_filter]
+  or: [VAnchorTotalWrappingFeeByTokenEvery15Min_filter]
+}
+
+enum VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  startInterval
+  endInterval
+  fees
+}
+
+input VAnchorTotalWrappingFeeByToken_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalWrappingFeeByToken_filter]
+  or: [VAnchorTotalWrappingFeeByToken_filter]
+}
+
+enum VAnchorTotalWrappingFeeByToken_orderBy {
+  id
+  vAnchorAddress
+  tokenSymbol
+  tokenAddress
+  fees
+}
+
+input VAnchorTotalWrappingFee_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  fees: BigInt
+  fees_not: BigInt
+  fees_gt: BigInt
+  fees_lt: BigInt
+  fees_gte: BigInt
+  fees_lte: BigInt
+  fees_in: [BigInt!]
+  fees_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTotalWrappingFee_filter]
+  or: [VAnchorTotalWrappingFee_filter]
+}
+
+enum VAnchorTotalWrappingFee_orderBy {
+  id
+  fees
+}
+
+type VAnchorTransferLog {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  timestamp: BigInt!
+}
+
+input VAnchorTransferLog_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorTransferLog_filter]
+  or: [VAnchorTransferLog_filter]
+}
+
+enum VAnchorTransferLog_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  timestamp
+}
+
+type VAnchorWithdrawal {
+  id: String!
+  withdrawal: BigInt!
+  averageWithdrawal: BigInt!
+  totalCount: BigInt!
+}
+
+type VAnchorWithdrawalByToken {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  withdrawal: BigInt!
+  averageWithdrawal: BigInt!
+  totalCount: BigInt!
+}
+
+type VAnchorWithdrawalByTokenEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  withdrawal: BigInt!
+  averageWithdrawal: BigInt!
+  totalCount: BigInt!
+}
+
+input VAnchorWithdrawalByTokenEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  withdrawal: BigInt
+  withdrawal_not: BigInt
+  withdrawal_gt: BigInt
+  withdrawal_lt: BigInt
+  withdrawal_gte: BigInt
+  withdrawal_lte: BigInt
+  withdrawal_in: [BigInt!]
+  withdrawal_not_in: [BigInt!]
+  averageWithdrawal: BigInt
+  averageWithdrawal_not: BigInt
+  averageWithdrawal_gt: BigInt
+  averageWithdrawal_lt: BigInt
+  averageWithdrawal_gte: BigInt
+  averageWithdrawal_lte: BigInt
+  averageWithdrawal_in: [BigInt!]
+  averageWithdrawal_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorWithdrawalByTokenEvery15Min_filter]
+  or: [VAnchorWithdrawalByTokenEvery15Min_filter]
+}
+
+enum VAnchorWithdrawalByTokenEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  startInterval
+  endInterval
+  withdrawal
+  averageWithdrawal
+  totalCount
+}
+
+input VAnchorWithdrawalByToken_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  withdrawal: BigInt
+  withdrawal_not: BigInt
+  withdrawal_gt: BigInt
+  withdrawal_lt: BigInt
+  withdrawal_gte: BigInt
+  withdrawal_lte: BigInt
+  withdrawal_in: [BigInt!]
+  withdrawal_not_in: [BigInt!]
+  averageWithdrawal: BigInt
+  averageWithdrawal_not: BigInt
+  averageWithdrawal_gt: BigInt
+  averageWithdrawal_lt: BigInt
+  averageWithdrawal_gte: BigInt
+  averageWithdrawal_lte: BigInt
+  averageWithdrawal_in: [BigInt!]
+  averageWithdrawal_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorWithdrawalByToken_filter]
+  or: [VAnchorWithdrawalByToken_filter]
+}
+
+enum VAnchorWithdrawalByToken_orderBy {
+  id
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  withdrawal
+  averageWithdrawal
+  totalCount
+}
+
+type VAnchorWithdrawalEvery15Min {
+  id: String!
+  vAnchorAddress: Bytes!
+  startInterval: BigInt!
+  endInterval: BigInt!
+  withdrawal: BigInt!
+  averageWithdrawal: BigInt!
+  totalCount: BigInt!
+}
+
+input VAnchorWithdrawalEvery15Min_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  startInterval: BigInt
+  startInterval_not: BigInt
+  startInterval_gt: BigInt
+  startInterval_lt: BigInt
+  startInterval_gte: BigInt
+  startInterval_lte: BigInt
+  startInterval_in: [BigInt!]
+  startInterval_not_in: [BigInt!]
+  endInterval: BigInt
+  endInterval_not: BigInt
+  endInterval_gt: BigInt
+  endInterval_lt: BigInt
+  endInterval_gte: BigInt
+  endInterval_lte: BigInt
+  endInterval_in: [BigInt!]
+  endInterval_not_in: [BigInt!]
+  withdrawal: BigInt
+  withdrawal_not: BigInt
+  withdrawal_gt: BigInt
+  withdrawal_lt: BigInt
+  withdrawal_gte: BigInt
+  withdrawal_lte: BigInt
+  withdrawal_in: [BigInt!]
+  withdrawal_not_in: [BigInt!]
+  averageWithdrawal: BigInt
+  averageWithdrawal_not: BigInt
+  averageWithdrawal_gt: BigInt
+  averageWithdrawal_lt: BigInt
+  averageWithdrawal_gte: BigInt
+  averageWithdrawal_lte: BigInt
+  averageWithdrawal_in: [BigInt!]
+  averageWithdrawal_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorWithdrawalEvery15Min_filter]
+  or: [VAnchorWithdrawalEvery15Min_filter]
+}
+
+enum VAnchorWithdrawalEvery15Min_orderBy {
+  id
+  vAnchorAddress
+  startInterval
+  endInterval
+  withdrawal
+  averageWithdrawal
+  totalCount
+}
+
+type VAnchorWithdrawalLog {
+  id: String!
+  withdrawal: BigInt!
+  vAnchorAddress: Bytes!
+  tokenAddress: Bytes!
+  tokenSymbol: String!
+  timestamp: BigInt!
+}
+
+input VAnchorWithdrawalLog_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  withdrawal: BigInt
+  withdrawal_not: BigInt
+  withdrawal_gt: BigInt
+  withdrawal_lt: BigInt
+  withdrawal_gte: BigInt
+  withdrawal_lte: BigInt
+  withdrawal_in: [BigInt!]
+  withdrawal_not_in: [BigInt!]
+  vAnchorAddress: Bytes
+  vAnchorAddress_not: Bytes
+  vAnchorAddress_gt: Bytes
+  vAnchorAddress_lt: Bytes
+  vAnchorAddress_gte: Bytes
+  vAnchorAddress_lte: Bytes
+  vAnchorAddress_in: [Bytes!]
+  vAnchorAddress_not_in: [Bytes!]
+  vAnchorAddress_contains: Bytes
+  vAnchorAddress_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  tokenSymbol: String
+  tokenSymbol_not: String
+  tokenSymbol_gt: String
+  tokenSymbol_lt: String
+  tokenSymbol_gte: String
+  tokenSymbol_lte: String
+  tokenSymbol_in: [String!]
+  tokenSymbol_not_in: [String!]
+  tokenSymbol_contains: String
+  tokenSymbol_contains_nocase: String
+  tokenSymbol_not_contains: String
+  tokenSymbol_not_contains_nocase: String
+  tokenSymbol_starts_with: String
+  tokenSymbol_starts_with_nocase: String
+  tokenSymbol_not_starts_with: String
+  tokenSymbol_not_starts_with_nocase: String
+  tokenSymbol_ends_with: String
+  tokenSymbol_ends_with_nocase: String
+  tokenSymbol_not_ends_with: String
+  tokenSymbol_not_ends_with_nocase: String
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorWithdrawalLog_filter]
+  or: [VAnchorWithdrawalLog_filter]
+}
+
+enum VAnchorWithdrawalLog_orderBy {
+  id
+  withdrawal
+  vAnchorAddress
+  tokenAddress
+  tokenSymbol
+  timestamp
+}
+
+input VAnchorWithdrawal_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  withdrawal: BigInt
+  withdrawal_not: BigInt
+  withdrawal_gt: BigInt
+  withdrawal_lt: BigInt
+  withdrawal_gte: BigInt
+  withdrawal_lte: BigInt
+  withdrawal_in: [BigInt!]
+  withdrawal_not_in: [BigInt!]
+  averageWithdrawal: BigInt
+  averageWithdrawal_not: BigInt
+  averageWithdrawal_gt: BigInt
+  averageWithdrawal_lt: BigInt
+  averageWithdrawal_gte: BigInt
+  averageWithdrawal_lte: BigInt
+  averageWithdrawal_in: [BigInt!]
+  averageWithdrawal_not_in: [BigInt!]
+  totalCount: BigInt
+  totalCount_not: BigInt
+  totalCount_gt: BigInt
+  totalCount_lt: BigInt
+  totalCount_gte: BigInt
+  totalCount_lte: BigInt
+  totalCount_in: [BigInt!]
+  totalCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VAnchorWithdrawal_filter]
+  or: [VAnchorWithdrawal_filter]
+}
+
+enum VAnchorWithdrawal_orderBy {
+  id
+  withdrawal
+  averageWithdrawal
+  totalCount
+}
+
+type WrappingEventLog {
+  id: String!
+  sender: Bytes!
+  recipient: Bytes!
+  tokenAddress: Bytes!
+  wrappingFee: BigInt!
+  afterFeeAmount: BigInt!
+  timestamp: BigInt!
+}
+
+input WrappingEventLog_filter {
+  id: String
+  id_not: String
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  id_in: [String!]
+  id_not_in: [String!]
+  id_contains: String
+  id_contains_nocase: String
+  id_not_contains: String
+  id_not_contains_nocase: String
+  id_starts_with: String
+  id_starts_with_nocase: String
+  id_not_starts_with: String
+  id_not_starts_with_nocase: String
+  id_ends_with: String
+  id_ends_with_nocase: String
+  id_not_ends_with: String
+  id_not_ends_with_nocase: String
+  sender: Bytes
+  sender_not: Bytes
+  sender_gt: Bytes
+  sender_lt: Bytes
+  sender_gte: Bytes
+  sender_lte: Bytes
+  sender_in: [Bytes!]
+  sender_not_in: [Bytes!]
+  sender_contains: Bytes
+  sender_not_contains: Bytes
+  recipient: Bytes
+  recipient_not: Bytes
+  recipient_gt: Bytes
+  recipient_lt: Bytes
+  recipient_gte: Bytes
+  recipient_lte: Bytes
+  recipient_in: [Bytes!]
+  recipient_not_in: [Bytes!]
+  recipient_contains: Bytes
+  recipient_not_contains: Bytes
+  tokenAddress: Bytes
+  tokenAddress_not: Bytes
+  tokenAddress_gt: Bytes
+  tokenAddress_lt: Bytes
+  tokenAddress_gte: Bytes
+  tokenAddress_lte: Bytes
+  tokenAddress_in: [Bytes!]
+  tokenAddress_not_in: [Bytes!]
+  tokenAddress_contains: Bytes
+  tokenAddress_not_contains: Bytes
+  wrappingFee: BigInt
+  wrappingFee_not: BigInt
+  wrappingFee_gt: BigInt
+  wrappingFee_lt: BigInt
+  wrappingFee_gte: BigInt
+  wrappingFee_lte: BigInt
+  wrappingFee_in: [BigInt!]
+  wrappingFee_not_in: [BigInt!]
+  afterFeeAmount: BigInt
+  afterFeeAmount_not: BigInt
+  afterFeeAmount_gt: BigInt
+  afterFeeAmount_lt: BigInt
+  afterFeeAmount_gte: BigInt
+  afterFeeAmount_lte: BigInt
+  afterFeeAmount_in: [BigInt!]
+  afterFeeAmount_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [WrappingEventLog_filter]
+  or: [WrappingEventLog_filter]
+}
+
+enum WrappingEventLog_orderBy {
+  id
+  sender
+  recipient
+  tokenAddress
+  wrappingFee
+  afterFeeAmount
+  timestamp
+}
+
+type _Block_ {
+  """The hash of the block"""
+  hash: Bytes
+  """The block number"""
+  number: Int!
+  """Integer representation of the timestamp stored in blocks for the chain"""
+  timestamp: Int
+}
+
+"""The type for the top-level _meta field"""
+type _Meta_ {
+  """
+  Information about a specific subgraph block. The hash of the block
+  will be null if the _meta field has a block constraint that asks for
+  a block number. It will be filled if the _meta field has no block constraint
+  and therefore asks for the latest  block
+  
+  """
+  block: _Block_!
+  """The deployment ID"""
+  deployment: String!
+  """If `true`, the subgraph encountered indexing errors at some past block"""
+  hasIndexingErrors: Boolean!
+}
+
+enum _SubgraphErrorPolicy_ {
+  """Data will be returned even if the subgraph has indexing errors"""
+  allow
+  """
+  If the subgraph has indexing errors, data will be omitted. The default.
+  """
+  deny
+}

--- a/packages/vanchor-client/.graphclient/sources/vanchor/types.ts
+++ b/packages/vanchor-client/.graphclient/sources/vanchor/types.ts
@@ -1,0 +1,5068 @@
+// @ts-nocheck
+
+import { InContextSdkMethod } from '@graphql-mesh/types';
+import { MeshContext } from '@graphql-mesh/runtime';
+
+export namespace VanchorTypes {
+  export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  BigDecimal: any;
+  BigInt: any;
+  Bytes: any;
+};
+
+export type BlockChangedFilter = {
+  number_gte: Scalars['Int'];
+};
+
+export type Block_height = {
+  hash?: InputMaybe<Scalars['Bytes']>;
+  number?: InputMaybe<Scalars['Int']>;
+  number_gte?: InputMaybe<Scalars['Int']>;
+};
+
+export type EdgeAddition = {
+  id: Scalars['Bytes'];
+  chainID: Scalars['BigInt'];
+  latestLeafIndex: Scalars['BigInt'];
+  merkleRoot: Scalars['BigInt'];
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+};
+
+export type EdgeAddition_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  chainID?: InputMaybe<Scalars['BigInt']>;
+  chainID_not?: InputMaybe<Scalars['BigInt']>;
+  chainID_gt?: InputMaybe<Scalars['BigInt']>;
+  chainID_lt?: InputMaybe<Scalars['BigInt']>;
+  chainID_gte?: InputMaybe<Scalars['BigInt']>;
+  chainID_lte?: InputMaybe<Scalars['BigInt']>;
+  chainID_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  chainID_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  latestLeafIndex?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_not?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_gt?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_lt?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_gte?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_lte?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  latestLeafIndex_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  merkleRoot?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_not?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_gt?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_lt?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_gte?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_lte?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  merkleRoot_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<EdgeAddition_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<EdgeAddition_filter>>>;
+};
+
+export type EdgeAddition_orderBy =
+  | 'id'
+  | 'chainID'
+  | 'latestLeafIndex'
+  | 'merkleRoot'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+export type EdgeUpdate = {
+  id: Scalars['Bytes'];
+  chainID: Scalars['BigInt'];
+  latestLeafIndex: Scalars['BigInt'];
+  merkleRoot: Scalars['BigInt'];
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+};
+
+export type EdgeUpdate_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  chainID?: InputMaybe<Scalars['BigInt']>;
+  chainID_not?: InputMaybe<Scalars['BigInt']>;
+  chainID_gt?: InputMaybe<Scalars['BigInt']>;
+  chainID_lt?: InputMaybe<Scalars['BigInt']>;
+  chainID_gte?: InputMaybe<Scalars['BigInt']>;
+  chainID_lte?: InputMaybe<Scalars['BigInt']>;
+  chainID_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  chainID_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  latestLeafIndex?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_not?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_gt?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_lt?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_gte?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_lte?: InputMaybe<Scalars['BigInt']>;
+  latestLeafIndex_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  latestLeafIndex_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  merkleRoot?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_not?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_gt?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_lt?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_gte?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_lte?: InputMaybe<Scalars['BigInt']>;
+  merkleRoot_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  merkleRoot_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<EdgeUpdate_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<EdgeUpdate_filter>>>;
+};
+
+export type EdgeUpdate_orderBy =
+  | 'id'
+  | 'chainID'
+  | 'latestLeafIndex'
+  | 'merkleRoot'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+export type Encryptions = {
+  id: Scalars['Bytes'];
+  encryptedOutput1: Scalars['Bytes'];
+  encryptedOutput2: Scalars['Bytes'];
+};
+
+export type Encryptions_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_not?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_gt?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_lt?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_gte?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_lte?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  encryptedOutput1_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  encryptedOutput1_contains?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput1_not_contains?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_not?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_gt?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_lt?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_gte?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_lte?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  encryptedOutput2_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  encryptedOutput2_contains?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput2_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Encryptions_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Encryptions_filter>>>;
+};
+
+export type Encryptions_orderBy =
+  | 'id'
+  | 'encryptedOutput1'
+  | 'encryptedOutput2';
+
+export type ExternalData = {
+  id: Scalars['Bytes'];
+  recipient: Scalars['Bytes'];
+  extAmount: Scalars['BigInt'];
+  relayer: Scalars['Bytes'];
+  fee: Scalars['BigInt'];
+  refund: Scalars['BigInt'];
+  token: Scalars['String'];
+};
+
+export type ExternalData_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  recipient?: InputMaybe<Scalars['Bytes']>;
+  recipient_not?: InputMaybe<Scalars['Bytes']>;
+  recipient_gt?: InputMaybe<Scalars['Bytes']>;
+  recipient_lt?: InputMaybe<Scalars['Bytes']>;
+  recipient_gte?: InputMaybe<Scalars['Bytes']>;
+  recipient_lte?: InputMaybe<Scalars['Bytes']>;
+  recipient_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  recipient_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  recipient_contains?: InputMaybe<Scalars['Bytes']>;
+  recipient_not_contains?: InputMaybe<Scalars['Bytes']>;
+  extAmount?: InputMaybe<Scalars['BigInt']>;
+  extAmount_not?: InputMaybe<Scalars['BigInt']>;
+  extAmount_gt?: InputMaybe<Scalars['BigInt']>;
+  extAmount_lt?: InputMaybe<Scalars['BigInt']>;
+  extAmount_gte?: InputMaybe<Scalars['BigInt']>;
+  extAmount_lte?: InputMaybe<Scalars['BigInt']>;
+  extAmount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  extAmount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  relayer?: InputMaybe<Scalars['Bytes']>;
+  relayer_not?: InputMaybe<Scalars['Bytes']>;
+  relayer_gt?: InputMaybe<Scalars['Bytes']>;
+  relayer_lt?: InputMaybe<Scalars['Bytes']>;
+  relayer_gte?: InputMaybe<Scalars['Bytes']>;
+  relayer_lte?: InputMaybe<Scalars['Bytes']>;
+  relayer_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  relayer_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  relayer_contains?: InputMaybe<Scalars['Bytes']>;
+  relayer_not_contains?: InputMaybe<Scalars['Bytes']>;
+  fee?: InputMaybe<Scalars['BigInt']>;
+  fee_not?: InputMaybe<Scalars['BigInt']>;
+  fee_gt?: InputMaybe<Scalars['BigInt']>;
+  fee_lt?: InputMaybe<Scalars['BigInt']>;
+  fee_gte?: InputMaybe<Scalars['BigInt']>;
+  fee_lte?: InputMaybe<Scalars['BigInt']>;
+  fee_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fee_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  refund?: InputMaybe<Scalars['BigInt']>;
+  refund_not?: InputMaybe<Scalars['BigInt']>;
+  refund_gt?: InputMaybe<Scalars['BigInt']>;
+  refund_lt?: InputMaybe<Scalars['BigInt']>;
+  refund_gte?: InputMaybe<Scalars['BigInt']>;
+  refund_lte?: InputMaybe<Scalars['BigInt']>;
+  refund_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  refund_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  token?: InputMaybe<Scalars['String']>;
+  token_not?: InputMaybe<Scalars['String']>;
+  token_gt?: InputMaybe<Scalars['String']>;
+  token_lt?: InputMaybe<Scalars['String']>;
+  token_gte?: InputMaybe<Scalars['String']>;
+  token_lte?: InputMaybe<Scalars['String']>;
+  token_in?: InputMaybe<Array<Scalars['String']>>;
+  token_not_in?: InputMaybe<Array<Scalars['String']>>;
+  token_contains?: InputMaybe<Scalars['String']>;
+  token_contains_nocase?: InputMaybe<Scalars['String']>;
+  token_not_contains?: InputMaybe<Scalars['String']>;
+  token_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  token_starts_with?: InputMaybe<Scalars['String']>;
+  token_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  token_not_starts_with?: InputMaybe<Scalars['String']>;
+  token_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  token_ends_with?: InputMaybe<Scalars['String']>;
+  token_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  token_not_ends_with?: InputMaybe<Scalars['String']>;
+  token_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<ExternalData_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<ExternalData_filter>>>;
+};
+
+export type ExternalData_orderBy =
+  | 'id'
+  | 'recipient'
+  | 'extAmount'
+  | 'relayer'
+  | 'fee'
+  | 'refund'
+  | 'token';
+
+export type Insertion = {
+  id: Scalars['Bytes'];
+  commitment: Scalars['BigInt'];
+  leafIndex: Scalars['BigInt'];
+  timestamp: Scalars['BigInt'];
+  newMerkleRoot: Scalars['BigInt'];
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+};
+
+export type Insertion_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  commitment?: InputMaybe<Scalars['BigInt']>;
+  commitment_not?: InputMaybe<Scalars['BigInt']>;
+  commitment_gt?: InputMaybe<Scalars['BigInt']>;
+  commitment_lt?: InputMaybe<Scalars['BigInt']>;
+  commitment_gte?: InputMaybe<Scalars['BigInt']>;
+  commitment_lte?: InputMaybe<Scalars['BigInt']>;
+  commitment_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  commitment_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  leafIndex?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_not?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_gt?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_lt?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_gte?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_lte?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  leafIndex_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  newMerkleRoot?: InputMaybe<Scalars['BigInt']>;
+  newMerkleRoot_not?: InputMaybe<Scalars['BigInt']>;
+  newMerkleRoot_gt?: InputMaybe<Scalars['BigInt']>;
+  newMerkleRoot_lt?: InputMaybe<Scalars['BigInt']>;
+  newMerkleRoot_gte?: InputMaybe<Scalars['BigInt']>;
+  newMerkleRoot_lte?: InputMaybe<Scalars['BigInt']>;
+  newMerkleRoot_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  newMerkleRoot_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Insertion_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Insertion_filter>>>;
+};
+
+export type Insertion_orderBy =
+  | 'id'
+  | 'commitment'
+  | 'leafIndex'
+  | 'timestamp'
+  | 'newMerkleRoot'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+export type NewCommitment = {
+  id: Scalars['Bytes'];
+  commitment: Scalars['BigInt'];
+  subTreeIndex: Scalars['BigInt'];
+  leafIndex: Scalars['BigInt'];
+  encryptedOutput: Scalars['Bytes'];
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+};
+
+export type NewCommitment_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  commitment?: InputMaybe<Scalars['BigInt']>;
+  commitment_not?: InputMaybe<Scalars['BigInt']>;
+  commitment_gt?: InputMaybe<Scalars['BigInt']>;
+  commitment_lt?: InputMaybe<Scalars['BigInt']>;
+  commitment_gte?: InputMaybe<Scalars['BigInt']>;
+  commitment_lte?: InputMaybe<Scalars['BigInt']>;
+  commitment_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  commitment_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  subTreeIndex?: InputMaybe<Scalars['BigInt']>;
+  subTreeIndex_not?: InputMaybe<Scalars['BigInt']>;
+  subTreeIndex_gt?: InputMaybe<Scalars['BigInt']>;
+  subTreeIndex_lt?: InputMaybe<Scalars['BigInt']>;
+  subTreeIndex_gte?: InputMaybe<Scalars['BigInt']>;
+  subTreeIndex_lte?: InputMaybe<Scalars['BigInt']>;
+  subTreeIndex_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  subTreeIndex_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  leafIndex?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_not?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_gt?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_lt?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_gte?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_lte?: InputMaybe<Scalars['BigInt']>;
+  leafIndex_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  leafIndex_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  encryptedOutput?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_not?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_gt?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_lt?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_gte?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_lte?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  encryptedOutput_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  encryptedOutput_contains?: InputMaybe<Scalars['Bytes']>;
+  encryptedOutput_not_contains?: InputMaybe<Scalars['Bytes']>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<NewCommitment_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<NewCommitment_filter>>>;
+};
+
+export type NewCommitment_orderBy =
+  | 'id'
+  | 'commitment'
+  | 'subTreeIndex'
+  | 'leafIndex'
+  | 'encryptedOutput'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+export type NewNullifier = {
+  id: Scalars['Bytes'];
+  nullifier: Scalars['BigInt'];
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+};
+
+export type NewNullifier_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  nullifier?: InputMaybe<Scalars['BigInt']>;
+  nullifier_not?: InputMaybe<Scalars['BigInt']>;
+  nullifier_gt?: InputMaybe<Scalars['BigInt']>;
+  nullifier_lt?: InputMaybe<Scalars['BigInt']>;
+  nullifier_gte?: InputMaybe<Scalars['BigInt']>;
+  nullifier_lte?: InputMaybe<Scalars['BigInt']>;
+  nullifier_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  nullifier_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<NewNullifier_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<NewNullifier_filter>>>;
+};
+
+export type NewNullifier_orderBy =
+  | 'id'
+  | 'nullifier'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+/** Defines the order direction, either ascending or descending */
+export type OrderDirection =
+  | 'asc'
+  | 'desc';
+
+export type PublicInputs = {
+  id: Scalars['Bytes'];
+  roots: Scalars['Bytes'];
+  extensionRoots: Scalars['Bytes'];
+  inputNullifiers: Array<Scalars['BigInt']>;
+  outputCommitments: Array<Scalars['BigInt']>;
+  publicAmount: Scalars['BigInt'];
+  extDataHash: Scalars['BigInt'];
+};
+
+export type PublicInputs_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  roots?: InputMaybe<Scalars['Bytes']>;
+  roots_not?: InputMaybe<Scalars['Bytes']>;
+  roots_gt?: InputMaybe<Scalars['Bytes']>;
+  roots_lt?: InputMaybe<Scalars['Bytes']>;
+  roots_gte?: InputMaybe<Scalars['Bytes']>;
+  roots_lte?: InputMaybe<Scalars['Bytes']>;
+  roots_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  roots_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  roots_contains?: InputMaybe<Scalars['Bytes']>;
+  roots_not_contains?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_not?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_gt?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_lt?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_gte?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_lte?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  extensionRoots_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  extensionRoots_contains?: InputMaybe<Scalars['Bytes']>;
+  extensionRoots_not_contains?: InputMaybe<Scalars['Bytes']>;
+  inputNullifiers?: InputMaybe<Array<Scalars['BigInt']>>;
+  inputNullifiers_not?: InputMaybe<Array<Scalars['BigInt']>>;
+  inputNullifiers_contains?: InputMaybe<Array<Scalars['BigInt']>>;
+  inputNullifiers_contains_nocase?: InputMaybe<Array<Scalars['BigInt']>>;
+  inputNullifiers_not_contains?: InputMaybe<Array<Scalars['BigInt']>>;
+  inputNullifiers_not_contains_nocase?: InputMaybe<Array<Scalars['BigInt']>>;
+  outputCommitments?: InputMaybe<Array<Scalars['BigInt']>>;
+  outputCommitments_not?: InputMaybe<Array<Scalars['BigInt']>>;
+  outputCommitments_contains?: InputMaybe<Array<Scalars['BigInt']>>;
+  outputCommitments_contains_nocase?: InputMaybe<Array<Scalars['BigInt']>>;
+  outputCommitments_not_contains?: InputMaybe<Array<Scalars['BigInt']>>;
+  outputCommitments_not_contains_nocase?: InputMaybe<Array<Scalars['BigInt']>>;
+  publicAmount?: InputMaybe<Scalars['BigInt']>;
+  publicAmount_not?: InputMaybe<Scalars['BigInt']>;
+  publicAmount_gt?: InputMaybe<Scalars['BigInt']>;
+  publicAmount_lt?: InputMaybe<Scalars['BigInt']>;
+  publicAmount_gte?: InputMaybe<Scalars['BigInt']>;
+  publicAmount_lte?: InputMaybe<Scalars['BigInt']>;
+  publicAmount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  publicAmount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  extDataHash?: InputMaybe<Scalars['BigInt']>;
+  extDataHash_not?: InputMaybe<Scalars['BigInt']>;
+  extDataHash_gt?: InputMaybe<Scalars['BigInt']>;
+  extDataHash_lt?: InputMaybe<Scalars['BigInt']>;
+  extDataHash_gte?: InputMaybe<Scalars['BigInt']>;
+  extDataHash_lte?: InputMaybe<Scalars['BigInt']>;
+  extDataHash_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  extDataHash_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<PublicInputs_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<PublicInputs_filter>>>;
+};
+
+export type PublicInputs_orderBy =
+  | 'id'
+  | 'roots'
+  | 'extensionRoots'
+  | 'inputNullifiers'
+  | 'outputCommitments'
+  | 'publicAmount'
+  | 'extDataHash';
+
+export type PublicKey = {
+  id: Scalars['Bytes'];
+  owner: Scalars['Bytes'];
+  key: Scalars['Bytes'];
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+};
+
+export type PublicKey_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  owner?: InputMaybe<Scalars['Bytes']>;
+  owner_not?: InputMaybe<Scalars['Bytes']>;
+  owner_gt?: InputMaybe<Scalars['Bytes']>;
+  owner_lt?: InputMaybe<Scalars['Bytes']>;
+  owner_gte?: InputMaybe<Scalars['Bytes']>;
+  owner_lte?: InputMaybe<Scalars['Bytes']>;
+  owner_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  owner_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  owner_contains?: InputMaybe<Scalars['Bytes']>;
+  owner_not_contains?: InputMaybe<Scalars['Bytes']>;
+  key?: InputMaybe<Scalars['Bytes']>;
+  key_not?: InputMaybe<Scalars['Bytes']>;
+  key_gt?: InputMaybe<Scalars['Bytes']>;
+  key_lt?: InputMaybe<Scalars['Bytes']>;
+  key_gte?: InputMaybe<Scalars['Bytes']>;
+  key_lte?: InputMaybe<Scalars['Bytes']>;
+  key_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  key_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  key_contains?: InputMaybe<Scalars['Bytes']>;
+  key_not_contains?: InputMaybe<Scalars['Bytes']>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<PublicKey_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<PublicKey_filter>>>;
+};
+
+export type PublicKey_orderBy =
+  | 'id'
+  | 'owner'
+  | 'key'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+export type Query = {
+  edgeAddition?: Maybe<EdgeAddition>;
+  edgeAdditions: Array<EdgeAddition>;
+  edgeUpdate?: Maybe<EdgeUpdate>;
+  edgeUpdates: Array<EdgeUpdate>;
+  insertion?: Maybe<Insertion>;
+  insertions: Array<Insertion>;
+  newCommitment?: Maybe<NewCommitment>;
+  newCommitments: Array<NewCommitment>;
+  newNullifier?: Maybe<NewNullifier>;
+  newNullifiers: Array<NewNullifier>;
+  publicKey?: Maybe<PublicKey>;
+  publicKeys: Array<PublicKey>;
+  token?: Maybe<Token>;
+  tokens: Array<Token>;
+  externalData?: Maybe<ExternalData>;
+  externalDatas: Array<ExternalData>;
+  publicInputs: Array<PublicInputs>;
+  encryptions: Array<Encryptions>;
+  shieldedTransaction?: Maybe<ShieldedTransaction>;
+  shieldedTransactions: Array<ShieldedTransaction>;
+  vanchorTotalValueLocked?: Maybe<VAnchorTotalValueLocked>;
+  vanchorTotalValueLockeds: Array<VAnchorTotalValueLocked>;
+  vanchorTotalValueLockedByToken?: Maybe<VAnchorTotalValueLockedByToken>;
+  vanchorTotalValueLockedByTokens: Array<VAnchorTotalValueLockedByToken>;
+  vanchorTotalValueLockedEvery15Min?: Maybe<VAnchorTotalValueLockedEvery15Min>;
+  vanchorTotalValueLockedEvery15Mins: Array<VAnchorTotalValueLockedEvery15Min>;
+  vanchorTotalValueLockedByTokenEvery15Min?: Maybe<VAnchorTotalValueLockedByTokenEvery15Min>;
+  vanchorTotalValueLockedByTokenEvery15Mins: Array<VAnchorTotalValueLockedByTokenEvery15Min>;
+  vanchorTotalRelayerFee?: Maybe<VAnchorTotalRelayerFee>;
+  vanchorTotalRelayerFees: Array<VAnchorTotalRelayerFee>;
+  vanchorTotalRelayerFeeByToken?: Maybe<VAnchorTotalRelayerFeeByToken>;
+  vanchorTotalRelayerFeeByTokens: Array<VAnchorTotalRelayerFeeByToken>;
+  vanchorTotalRelayerFee15Min?: Maybe<VAnchorTotalRelayerFee15Min>;
+  vanchorTotalRelayerFee15Mins: Array<VAnchorTotalRelayerFee15Min>;
+  vanchorTotalRelayerFeeByTokenEvery15Min?: Maybe<VAnchorTotalRelayerFeeByTokenEvery15Min>;
+  vanchorTotalRelayerFeeByTokenEvery15Mins: Array<VAnchorTotalRelayerFeeByTokenEvery15Min>;
+  vanchorTotalWrappingFee?: Maybe<VAnchorTotalWrappingFee>;
+  vanchorTotalWrappingFees: Array<VAnchorTotalWrappingFee>;
+  vanchorTotalWrappingFeeByToken?: Maybe<VAnchorTotalWrappingFeeByToken>;
+  vanchorTotalWrappingFeeByTokens: Array<VAnchorTotalWrappingFeeByToken>;
+  vanchorTotalWrappingFee15Min?: Maybe<VAnchorTotalWrappingFee15Min>;
+  vanchorTotalWrappingFee15Mins: Array<VAnchorTotalWrappingFee15Min>;
+  vanchorTotalWrappingFeeByTokenEvery15Min?: Maybe<VAnchorTotalWrappingFeeByTokenEvery15Min>;
+  vanchorTotalWrappingFeeByTokenEvery15Mins: Array<VAnchorTotalWrappingFeeByTokenEvery15Min>;
+  wrappingEventLog?: Maybe<WrappingEventLog>;
+  wrappingEventLogs: Array<WrappingEventLog>;
+  unwrappingEventLog?: Maybe<UnwrappingEventLog>;
+  unwrappingEventLogs: Array<UnwrappingEventLog>;
+  vanchorWithdrawalLog?: Maybe<VAnchorWithdrawalLog>;
+  vanchorWithdrawalLogs: Array<VAnchorWithdrawalLog>;
+  vanchorWithdrawal?: Maybe<VAnchorWithdrawal>;
+  vanchorWithdrawals: Array<VAnchorWithdrawal>;
+  vanchorWithdrawalByToken?: Maybe<VAnchorWithdrawalByToken>;
+  vanchorWithdrawalByTokens: Array<VAnchorWithdrawalByToken>;
+  vanchorWithdrawalEvery15Min?: Maybe<VAnchorWithdrawalEvery15Min>;
+  vanchorWithdrawalEvery15Mins: Array<VAnchorWithdrawalEvery15Min>;
+  vanchorWithdrawalByTokenEvery15Min?: Maybe<VAnchorWithdrawalByTokenEvery15Min>;
+  vanchorWithdrawalByTokenEvery15Mins: Array<VAnchorWithdrawalByTokenEvery15Min>;
+  vanchorDeposit?: Maybe<VAnchorDeposit>;
+  vanchorDeposits: Array<VAnchorDeposit>;
+  vanchorDepositByToken?: Maybe<VAnchorDepositByToken>;
+  vanchorDepositByTokens: Array<VAnchorDepositByToken>;
+  vanchorDepositEvery15Min?: Maybe<VAnchorDepositEvery15Min>;
+  vanchorDepositEvery15Mins: Array<VAnchorDepositEvery15Min>;
+  vanchorDepositByTokenEvery15Min?: Maybe<VAnchorDepositByTokenEvery15Min>;
+  vanchorDepositByTokenEvery15Mins: Array<VAnchorDepositByTokenEvery15Min>;
+  vanchorDepositLog?: Maybe<VAnchorDepositLog>;
+  vanchorDepositLogs: Array<VAnchorDepositLog>;
+  vanchorTransferLog?: Maybe<VAnchorTransferLog>;
+  vanchorTransferLogs: Array<VAnchorTransferLog>;
+  /** Access to subgraph metadata */
+  _meta?: Maybe<_Meta_>;
+};
+
+
+export type QueryedgeAdditionArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryedgeAdditionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<EdgeAddition_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<EdgeAddition_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryedgeUpdateArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryedgeUpdatesArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<EdgeUpdate_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<EdgeUpdate_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryinsertionArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryinsertionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Insertion_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Insertion_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerynewCommitmentArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerynewCommitmentsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<NewCommitment_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<NewCommitment_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerynewNullifierArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerynewNullifiersArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<NewNullifier_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<NewNullifier_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerypublicKeyArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerypublicKeysArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<PublicKey_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<PublicKey_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerytokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerytokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Token_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Token_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryexternalDataArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryexternalDatasArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<ExternalData_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<ExternalData_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerypublicInputsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<PublicInputs_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<PublicInputs_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryencryptionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Encryptions_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Encryptions_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryshieldedTransactionArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryshieldedTransactionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<ShieldedTransaction_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<ShieldedTransaction_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLocked_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLocked_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLockedByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLockedByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLockedEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLockedEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalValueLockedByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLockedByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLockedByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFeeArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFeesArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFee_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFee_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFeeByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFeeByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFeeByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFeeByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFee15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFee15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFee15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFee15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFeeByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalRelayerFeeByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFeeByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFeeArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFeesArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFee_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFee_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFeeByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFeeByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFeeByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFeeByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFee15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFee15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFee15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFee15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFeeByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTotalWrappingFeeByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFeeByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerywrappingEventLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerywrappingEventLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<WrappingEventLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<WrappingEventLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryunwrappingEventLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryunwrappingEventLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<UnwrappingEventLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<UnwrappingEventLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawal_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawal_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorWithdrawalByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDeposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDeposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorDepositLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTransferLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryvanchorTransferLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTransferLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTransferLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type Query_metaArgs = {
+  block?: InputMaybe<Block_height>;
+};
+
+export type ShieldedTransaction = {
+  id: Scalars['Bytes'];
+  vanchor: Scalars['Bytes'];
+  sender: Scalars['Bytes'];
+  value: Scalars['BigInt'];
+  proof: Scalars['Bytes'];
+  auxPublicInputs: Scalars['Bytes'];
+  externalData: ExternalData;
+  publicInputs: PublicInputs;
+  encryptions: Encryptions;
+  blockNumber: Scalars['BigInt'];
+  blockTimestamp: Scalars['BigInt'];
+  transactionHash: Scalars['Bytes'];
+};
+
+export type ShieldedTransaction_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  vanchor?: InputMaybe<Scalars['Bytes']>;
+  vanchor_not?: InputMaybe<Scalars['Bytes']>;
+  vanchor_gt?: InputMaybe<Scalars['Bytes']>;
+  vanchor_lt?: InputMaybe<Scalars['Bytes']>;
+  vanchor_gte?: InputMaybe<Scalars['Bytes']>;
+  vanchor_lte?: InputMaybe<Scalars['Bytes']>;
+  vanchor_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vanchor_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vanchor_contains?: InputMaybe<Scalars['Bytes']>;
+  vanchor_not_contains?: InputMaybe<Scalars['Bytes']>;
+  sender?: InputMaybe<Scalars['Bytes']>;
+  sender_not?: InputMaybe<Scalars['Bytes']>;
+  sender_gt?: InputMaybe<Scalars['Bytes']>;
+  sender_lt?: InputMaybe<Scalars['Bytes']>;
+  sender_gte?: InputMaybe<Scalars['Bytes']>;
+  sender_lte?: InputMaybe<Scalars['Bytes']>;
+  sender_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  sender_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  sender_contains?: InputMaybe<Scalars['Bytes']>;
+  sender_not_contains?: InputMaybe<Scalars['Bytes']>;
+  value?: InputMaybe<Scalars['BigInt']>;
+  value_not?: InputMaybe<Scalars['BigInt']>;
+  value_gt?: InputMaybe<Scalars['BigInt']>;
+  value_lt?: InputMaybe<Scalars['BigInt']>;
+  value_gte?: InputMaybe<Scalars['BigInt']>;
+  value_lte?: InputMaybe<Scalars['BigInt']>;
+  value_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  value_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  proof?: InputMaybe<Scalars['Bytes']>;
+  proof_not?: InputMaybe<Scalars['Bytes']>;
+  proof_gt?: InputMaybe<Scalars['Bytes']>;
+  proof_lt?: InputMaybe<Scalars['Bytes']>;
+  proof_gte?: InputMaybe<Scalars['Bytes']>;
+  proof_lte?: InputMaybe<Scalars['Bytes']>;
+  proof_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  proof_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  proof_contains?: InputMaybe<Scalars['Bytes']>;
+  proof_not_contains?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_not?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_gt?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_lt?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_gte?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_lte?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  auxPublicInputs_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  auxPublicInputs_contains?: InputMaybe<Scalars['Bytes']>;
+  auxPublicInputs_not_contains?: InputMaybe<Scalars['Bytes']>;
+  externalData?: InputMaybe<Scalars['String']>;
+  externalData_not?: InputMaybe<Scalars['String']>;
+  externalData_gt?: InputMaybe<Scalars['String']>;
+  externalData_lt?: InputMaybe<Scalars['String']>;
+  externalData_gte?: InputMaybe<Scalars['String']>;
+  externalData_lte?: InputMaybe<Scalars['String']>;
+  externalData_in?: InputMaybe<Array<Scalars['String']>>;
+  externalData_not_in?: InputMaybe<Array<Scalars['String']>>;
+  externalData_contains?: InputMaybe<Scalars['String']>;
+  externalData_contains_nocase?: InputMaybe<Scalars['String']>;
+  externalData_not_contains?: InputMaybe<Scalars['String']>;
+  externalData_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  externalData_starts_with?: InputMaybe<Scalars['String']>;
+  externalData_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  externalData_not_starts_with?: InputMaybe<Scalars['String']>;
+  externalData_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  externalData_ends_with?: InputMaybe<Scalars['String']>;
+  externalData_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  externalData_not_ends_with?: InputMaybe<Scalars['String']>;
+  externalData_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  externalData_?: InputMaybe<ExternalData_filter>;
+  publicInputs?: InputMaybe<Scalars['String']>;
+  publicInputs_not?: InputMaybe<Scalars['String']>;
+  publicInputs_gt?: InputMaybe<Scalars['String']>;
+  publicInputs_lt?: InputMaybe<Scalars['String']>;
+  publicInputs_gte?: InputMaybe<Scalars['String']>;
+  publicInputs_lte?: InputMaybe<Scalars['String']>;
+  publicInputs_in?: InputMaybe<Array<Scalars['String']>>;
+  publicInputs_not_in?: InputMaybe<Array<Scalars['String']>>;
+  publicInputs_contains?: InputMaybe<Scalars['String']>;
+  publicInputs_contains_nocase?: InputMaybe<Scalars['String']>;
+  publicInputs_not_contains?: InputMaybe<Scalars['String']>;
+  publicInputs_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  publicInputs_starts_with?: InputMaybe<Scalars['String']>;
+  publicInputs_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  publicInputs_not_starts_with?: InputMaybe<Scalars['String']>;
+  publicInputs_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  publicInputs_ends_with?: InputMaybe<Scalars['String']>;
+  publicInputs_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  publicInputs_not_ends_with?: InputMaybe<Scalars['String']>;
+  publicInputs_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  publicInputs_?: InputMaybe<PublicInputs_filter>;
+  encryptions?: InputMaybe<Scalars['String']>;
+  encryptions_not?: InputMaybe<Scalars['String']>;
+  encryptions_gt?: InputMaybe<Scalars['String']>;
+  encryptions_lt?: InputMaybe<Scalars['String']>;
+  encryptions_gte?: InputMaybe<Scalars['String']>;
+  encryptions_lte?: InputMaybe<Scalars['String']>;
+  encryptions_in?: InputMaybe<Array<Scalars['String']>>;
+  encryptions_not_in?: InputMaybe<Array<Scalars['String']>>;
+  encryptions_contains?: InputMaybe<Scalars['String']>;
+  encryptions_contains_nocase?: InputMaybe<Scalars['String']>;
+  encryptions_not_contains?: InputMaybe<Scalars['String']>;
+  encryptions_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  encryptions_starts_with?: InputMaybe<Scalars['String']>;
+  encryptions_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  encryptions_not_starts_with?: InputMaybe<Scalars['String']>;
+  encryptions_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  encryptions_ends_with?: InputMaybe<Scalars['String']>;
+  encryptions_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  encryptions_not_ends_with?: InputMaybe<Scalars['String']>;
+  encryptions_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  encryptions_?: InputMaybe<Encryptions_filter>;
+  blockNumber?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_not?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  blockTimestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  blockTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<ShieldedTransaction_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<ShieldedTransaction_filter>>>;
+};
+
+export type ShieldedTransaction_orderBy =
+  | 'id'
+  | 'vanchor'
+  | 'sender'
+  | 'value'
+  | 'proof'
+  | 'auxPublicInputs'
+  | 'externalData'
+  | 'externalData__id'
+  | 'externalData__recipient'
+  | 'externalData__extAmount'
+  | 'externalData__relayer'
+  | 'externalData__fee'
+  | 'externalData__refund'
+  | 'externalData__token'
+  | 'publicInputs'
+  | 'publicInputs__id'
+  | 'publicInputs__roots'
+  | 'publicInputs__extensionRoots'
+  | 'publicInputs__publicAmount'
+  | 'publicInputs__extDataHash'
+  | 'encryptions'
+  | 'encryptions__id'
+  | 'encryptions__encryptedOutput1'
+  | 'encryptions__encryptedOutput2'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'transactionHash';
+
+export type Subscription = {
+  edgeAddition?: Maybe<EdgeAddition>;
+  edgeAdditions: Array<EdgeAddition>;
+  edgeUpdate?: Maybe<EdgeUpdate>;
+  edgeUpdates: Array<EdgeUpdate>;
+  insertion?: Maybe<Insertion>;
+  insertions: Array<Insertion>;
+  newCommitment?: Maybe<NewCommitment>;
+  newCommitments: Array<NewCommitment>;
+  newNullifier?: Maybe<NewNullifier>;
+  newNullifiers: Array<NewNullifier>;
+  publicKey?: Maybe<PublicKey>;
+  publicKeys: Array<PublicKey>;
+  token?: Maybe<Token>;
+  tokens: Array<Token>;
+  externalData?: Maybe<ExternalData>;
+  externalDatas: Array<ExternalData>;
+  publicInputs: Array<PublicInputs>;
+  encryptions: Array<Encryptions>;
+  shieldedTransaction?: Maybe<ShieldedTransaction>;
+  shieldedTransactions: Array<ShieldedTransaction>;
+  vanchorTotalValueLocked?: Maybe<VAnchorTotalValueLocked>;
+  vanchorTotalValueLockeds: Array<VAnchorTotalValueLocked>;
+  vanchorTotalValueLockedByToken?: Maybe<VAnchorTotalValueLockedByToken>;
+  vanchorTotalValueLockedByTokens: Array<VAnchorTotalValueLockedByToken>;
+  vanchorTotalValueLockedEvery15Min?: Maybe<VAnchorTotalValueLockedEvery15Min>;
+  vanchorTotalValueLockedEvery15Mins: Array<VAnchorTotalValueLockedEvery15Min>;
+  vanchorTotalValueLockedByTokenEvery15Min?: Maybe<VAnchorTotalValueLockedByTokenEvery15Min>;
+  vanchorTotalValueLockedByTokenEvery15Mins: Array<VAnchorTotalValueLockedByTokenEvery15Min>;
+  vanchorTotalRelayerFee?: Maybe<VAnchorTotalRelayerFee>;
+  vanchorTotalRelayerFees: Array<VAnchorTotalRelayerFee>;
+  vanchorTotalRelayerFeeByToken?: Maybe<VAnchorTotalRelayerFeeByToken>;
+  vanchorTotalRelayerFeeByTokens: Array<VAnchorTotalRelayerFeeByToken>;
+  vanchorTotalRelayerFee15Min?: Maybe<VAnchorTotalRelayerFee15Min>;
+  vanchorTotalRelayerFee15Mins: Array<VAnchorTotalRelayerFee15Min>;
+  vanchorTotalRelayerFeeByTokenEvery15Min?: Maybe<VAnchorTotalRelayerFeeByTokenEvery15Min>;
+  vanchorTotalRelayerFeeByTokenEvery15Mins: Array<VAnchorTotalRelayerFeeByTokenEvery15Min>;
+  vanchorTotalWrappingFee?: Maybe<VAnchorTotalWrappingFee>;
+  vanchorTotalWrappingFees: Array<VAnchorTotalWrappingFee>;
+  vanchorTotalWrappingFeeByToken?: Maybe<VAnchorTotalWrappingFeeByToken>;
+  vanchorTotalWrappingFeeByTokens: Array<VAnchorTotalWrappingFeeByToken>;
+  vanchorTotalWrappingFee15Min?: Maybe<VAnchorTotalWrappingFee15Min>;
+  vanchorTotalWrappingFee15Mins: Array<VAnchorTotalWrappingFee15Min>;
+  vanchorTotalWrappingFeeByTokenEvery15Min?: Maybe<VAnchorTotalWrappingFeeByTokenEvery15Min>;
+  vanchorTotalWrappingFeeByTokenEvery15Mins: Array<VAnchorTotalWrappingFeeByTokenEvery15Min>;
+  wrappingEventLog?: Maybe<WrappingEventLog>;
+  wrappingEventLogs: Array<WrappingEventLog>;
+  unwrappingEventLog?: Maybe<UnwrappingEventLog>;
+  unwrappingEventLogs: Array<UnwrappingEventLog>;
+  vanchorWithdrawalLog?: Maybe<VAnchorWithdrawalLog>;
+  vanchorWithdrawalLogs: Array<VAnchorWithdrawalLog>;
+  vanchorWithdrawal?: Maybe<VAnchorWithdrawal>;
+  vanchorWithdrawals: Array<VAnchorWithdrawal>;
+  vanchorWithdrawalByToken?: Maybe<VAnchorWithdrawalByToken>;
+  vanchorWithdrawalByTokens: Array<VAnchorWithdrawalByToken>;
+  vanchorWithdrawalEvery15Min?: Maybe<VAnchorWithdrawalEvery15Min>;
+  vanchorWithdrawalEvery15Mins: Array<VAnchorWithdrawalEvery15Min>;
+  vanchorWithdrawalByTokenEvery15Min?: Maybe<VAnchorWithdrawalByTokenEvery15Min>;
+  vanchorWithdrawalByTokenEvery15Mins: Array<VAnchorWithdrawalByTokenEvery15Min>;
+  vanchorDeposit?: Maybe<VAnchorDeposit>;
+  vanchorDeposits: Array<VAnchorDeposit>;
+  vanchorDepositByToken?: Maybe<VAnchorDepositByToken>;
+  vanchorDepositByTokens: Array<VAnchorDepositByToken>;
+  vanchorDepositEvery15Min?: Maybe<VAnchorDepositEvery15Min>;
+  vanchorDepositEvery15Mins: Array<VAnchorDepositEvery15Min>;
+  vanchorDepositByTokenEvery15Min?: Maybe<VAnchorDepositByTokenEvery15Min>;
+  vanchorDepositByTokenEvery15Mins: Array<VAnchorDepositByTokenEvery15Min>;
+  vanchorDepositLog?: Maybe<VAnchorDepositLog>;
+  vanchorDepositLogs: Array<VAnchorDepositLog>;
+  vanchorTransferLog?: Maybe<VAnchorTransferLog>;
+  vanchorTransferLogs: Array<VAnchorTransferLog>;
+  /** Access to subgraph metadata */
+  _meta?: Maybe<_Meta_>;
+};
+
+
+export type SubscriptionedgeAdditionArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionedgeAdditionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<EdgeAddition_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<EdgeAddition_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionedgeUpdateArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionedgeUpdatesArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<EdgeUpdate_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<EdgeUpdate_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptioninsertionArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptioninsertionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Insertion_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Insertion_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionnewCommitmentArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionnewCommitmentsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<NewCommitment_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<NewCommitment_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionnewNullifierArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionnewNullifiersArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<NewNullifier_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<NewNullifier_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionpublicKeyArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionpublicKeysArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<PublicKey_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<PublicKey_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiontokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiontokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Token_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Token_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionexternalDataArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionexternalDatasArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<ExternalData_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<ExternalData_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionpublicInputsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<PublicInputs_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<PublicInputs_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionencryptionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Encryptions_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Encryptions_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionshieldedTransactionArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionshieldedTransactionsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<ShieldedTransaction_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<ShieldedTransaction_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLocked_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLocked_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLockedByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLockedByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLockedEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLockedEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalValueLockedByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalValueLockedByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalValueLockedByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFeeArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFeesArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFee_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFee_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFeeByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFeeByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFeeByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFeeByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFee15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFee15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFee15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFee15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFeeByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalRelayerFeeByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalRelayerFeeByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFeeArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFeesArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFee_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFee_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFeeByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFeeByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFeeByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFeeByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFee15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFee15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFee15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFee15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFeeByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTotalWrappingFeeByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTotalWrappingFeeByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionwrappingEventLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionwrappingEventLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<WrappingEventLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<WrappingEventLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionunwrappingEventLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionunwrappingEventLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<UnwrappingEventLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<UnwrappingEventLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawal_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawal_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorWithdrawalByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorWithdrawalByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorWithdrawalByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDeposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDeposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositByTokenArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositByTokensArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositByToken_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositByToken_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositByTokenEvery15MinArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositByTokenEvery15MinsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositByTokenEvery15Min_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositByTokenEvery15Min_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorDepositLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorDepositLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorDepositLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTransferLogArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionvanchorTransferLogsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<VAnchorTransferLog_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<VAnchorTransferLog_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type Subscription_metaArgs = {
+  block?: InputMaybe<Block_height>;
+};
+
+export type Token = {
+  id: Scalars['Bytes'];
+  address: Scalars['Bytes'];
+  decimals: Scalars['Int'];
+  name: Scalars['String'];
+  symbol: Scalars['String'];
+};
+
+export type Token_filter = {
+  id?: InputMaybe<Scalars['Bytes']>;
+  id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
+  id_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  id_contains?: InputMaybe<Scalars['Bytes']>;
+  id_not_contains?: InputMaybe<Scalars['Bytes']>;
+  address?: InputMaybe<Scalars['Bytes']>;
+  address_not?: InputMaybe<Scalars['Bytes']>;
+  address_gt?: InputMaybe<Scalars['Bytes']>;
+  address_lt?: InputMaybe<Scalars['Bytes']>;
+  address_gte?: InputMaybe<Scalars['Bytes']>;
+  address_lte?: InputMaybe<Scalars['Bytes']>;
+  address_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  address_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  address_contains?: InputMaybe<Scalars['Bytes']>;
+  address_not_contains?: InputMaybe<Scalars['Bytes']>;
+  decimals?: InputMaybe<Scalars['Int']>;
+  decimals_not?: InputMaybe<Scalars['Int']>;
+  decimals_gt?: InputMaybe<Scalars['Int']>;
+  decimals_lt?: InputMaybe<Scalars['Int']>;
+  decimals_gte?: InputMaybe<Scalars['Int']>;
+  decimals_lte?: InputMaybe<Scalars['Int']>;
+  decimals_in?: InputMaybe<Array<Scalars['Int']>>;
+  decimals_not_in?: InputMaybe<Array<Scalars['Int']>>;
+  name?: InputMaybe<Scalars['String']>;
+  name_not?: InputMaybe<Scalars['String']>;
+  name_gt?: InputMaybe<Scalars['String']>;
+  name_lt?: InputMaybe<Scalars['String']>;
+  name_gte?: InputMaybe<Scalars['String']>;
+  name_lte?: InputMaybe<Scalars['String']>;
+  name_in?: InputMaybe<Array<Scalars['String']>>;
+  name_not_in?: InputMaybe<Array<Scalars['String']>>;
+  name_contains?: InputMaybe<Scalars['String']>;
+  name_contains_nocase?: InputMaybe<Scalars['String']>;
+  name_not_contains?: InputMaybe<Scalars['String']>;
+  name_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  name_starts_with?: InputMaybe<Scalars['String']>;
+  name_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  name_not_starts_with?: InputMaybe<Scalars['String']>;
+  name_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  name_ends_with?: InputMaybe<Scalars['String']>;
+  name_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  name_not_ends_with?: InputMaybe<Scalars['String']>;
+  name_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  symbol?: InputMaybe<Scalars['String']>;
+  symbol_not?: InputMaybe<Scalars['String']>;
+  symbol_gt?: InputMaybe<Scalars['String']>;
+  symbol_lt?: InputMaybe<Scalars['String']>;
+  symbol_gte?: InputMaybe<Scalars['String']>;
+  symbol_lte?: InputMaybe<Scalars['String']>;
+  symbol_in?: InputMaybe<Array<Scalars['String']>>;
+  symbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  symbol_contains?: InputMaybe<Scalars['String']>;
+  symbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  symbol_not_contains?: InputMaybe<Scalars['String']>;
+  symbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  symbol_starts_with?: InputMaybe<Scalars['String']>;
+  symbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  symbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  symbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  symbol_ends_with?: InputMaybe<Scalars['String']>;
+  symbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  symbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  symbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Token_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Token_filter>>>;
+};
+
+export type Token_orderBy =
+  | 'id'
+  | 'address'
+  | 'decimals'
+  | 'name'
+  | 'symbol';
+
+export type UnwrappingEventLog = {
+  id: Scalars['String'];
+  sender: Scalars['Bytes'];
+  recipient: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  amount: Scalars['BigInt'];
+  timestamp: Scalars['BigInt'];
+};
+
+export type UnwrappingEventLog_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  sender?: InputMaybe<Scalars['Bytes']>;
+  sender_not?: InputMaybe<Scalars['Bytes']>;
+  sender_gt?: InputMaybe<Scalars['Bytes']>;
+  sender_lt?: InputMaybe<Scalars['Bytes']>;
+  sender_gte?: InputMaybe<Scalars['Bytes']>;
+  sender_lte?: InputMaybe<Scalars['Bytes']>;
+  sender_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  sender_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  sender_contains?: InputMaybe<Scalars['Bytes']>;
+  sender_not_contains?: InputMaybe<Scalars['Bytes']>;
+  recipient?: InputMaybe<Scalars['Bytes']>;
+  recipient_not?: InputMaybe<Scalars['Bytes']>;
+  recipient_gt?: InputMaybe<Scalars['Bytes']>;
+  recipient_lt?: InputMaybe<Scalars['Bytes']>;
+  recipient_gte?: InputMaybe<Scalars['Bytes']>;
+  recipient_lte?: InputMaybe<Scalars['Bytes']>;
+  recipient_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  recipient_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  recipient_contains?: InputMaybe<Scalars['Bytes']>;
+  recipient_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  amount?: InputMaybe<Scalars['BigInt']>;
+  amount_not?: InputMaybe<Scalars['BigInt']>;
+  amount_gt?: InputMaybe<Scalars['BigInt']>;
+  amount_lt?: InputMaybe<Scalars['BigInt']>;
+  amount_gte?: InputMaybe<Scalars['BigInt']>;
+  amount_lte?: InputMaybe<Scalars['BigInt']>;
+  amount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  amount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<UnwrappingEventLog_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<UnwrappingEventLog_filter>>>;
+};
+
+export type UnwrappingEventLog_orderBy =
+  | 'id'
+  | 'sender'
+  | 'recipient'
+  | 'tokenAddress'
+  | 'amount'
+  | 'timestamp';
+
+export type VAnchorDeposit = {
+  id: Scalars['String'];
+  deposit: Scalars['BigInt'];
+  averageDeposit: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorDepositByToken = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  deposit: Scalars['BigInt'];
+  averageDeposit: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorDepositByTokenEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  deposit: Scalars['BigInt'];
+  averageDeposit: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorDepositByTokenEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit?: InputMaybe<Scalars['BigInt']>;
+  deposit_not?: InputMaybe<Scalars['BigInt']>;
+  deposit_gt?: InputMaybe<Scalars['BigInt']>;
+  deposit_lt?: InputMaybe<Scalars['BigInt']>;
+  deposit_gte?: InputMaybe<Scalars['BigInt']>;
+  deposit_lte?: InputMaybe<Scalars['BigInt']>;
+  deposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_not?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorDepositByTokenEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorDepositByTokenEvery15Min_filter>>>;
+};
+
+export type VAnchorDepositByTokenEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'startInterval'
+  | 'endInterval'
+  | 'deposit'
+  | 'averageDeposit'
+  | 'totalCount';
+
+export type VAnchorDepositByToken_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  deposit?: InputMaybe<Scalars['BigInt']>;
+  deposit_not?: InputMaybe<Scalars['BigInt']>;
+  deposit_gt?: InputMaybe<Scalars['BigInt']>;
+  deposit_lt?: InputMaybe<Scalars['BigInt']>;
+  deposit_gte?: InputMaybe<Scalars['BigInt']>;
+  deposit_lte?: InputMaybe<Scalars['BigInt']>;
+  deposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_not?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorDepositByToken_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorDepositByToken_filter>>>;
+};
+
+export type VAnchorDepositByToken_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'deposit'
+  | 'averageDeposit'
+  | 'totalCount';
+
+export type VAnchorDepositEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  deposit: Scalars['BigInt'];
+  averageDeposit: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorDepositEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit?: InputMaybe<Scalars['BigInt']>;
+  deposit_not?: InputMaybe<Scalars['BigInt']>;
+  deposit_gt?: InputMaybe<Scalars['BigInt']>;
+  deposit_lt?: InputMaybe<Scalars['BigInt']>;
+  deposit_gte?: InputMaybe<Scalars['BigInt']>;
+  deposit_lte?: InputMaybe<Scalars['BigInt']>;
+  deposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_not?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorDepositEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorDepositEvery15Min_filter>>>;
+};
+
+export type VAnchorDepositEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'startInterval'
+  | 'endInterval'
+  | 'deposit'
+  | 'averageDeposit'
+  | 'totalCount';
+
+export type VAnchorDepositLog = {
+  id: Scalars['String'];
+  deposit: Scalars['BigInt'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  timestamp: Scalars['BigInt'];
+};
+
+export type VAnchorDepositLog_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  deposit?: InputMaybe<Scalars['BigInt']>;
+  deposit_not?: InputMaybe<Scalars['BigInt']>;
+  deposit_gt?: InputMaybe<Scalars['BigInt']>;
+  deposit_lt?: InputMaybe<Scalars['BigInt']>;
+  deposit_gte?: InputMaybe<Scalars['BigInt']>;
+  deposit_lte?: InputMaybe<Scalars['BigInt']>;
+  deposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorDepositLog_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorDepositLog_filter>>>;
+};
+
+export type VAnchorDepositLog_orderBy =
+  | 'id'
+  | 'deposit'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'timestamp';
+
+export type VAnchorDeposit_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  deposit?: InputMaybe<Scalars['BigInt']>;
+  deposit_not?: InputMaybe<Scalars['BigInt']>;
+  deposit_gt?: InputMaybe<Scalars['BigInt']>;
+  deposit_lt?: InputMaybe<Scalars['BigInt']>;
+  deposit_gte?: InputMaybe<Scalars['BigInt']>;
+  deposit_lte?: InputMaybe<Scalars['BigInt']>;
+  deposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_not?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lt?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_gte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_lte?: InputMaybe<Scalars['BigInt']>;
+  averageDeposit_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageDeposit_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorDeposit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorDeposit_filter>>>;
+};
+
+export type VAnchorDeposit_orderBy =
+  | 'id'
+  | 'deposit'
+  | 'averageDeposit'
+  | 'totalCount';
+
+export type VAnchorTotalRelayerFee = {
+  id: Scalars['String'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalRelayerFee15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalRelayerFee15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFee15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFee15Min_filter>>>;
+};
+
+export type VAnchorTotalRelayerFee15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'startInterval'
+  | 'endInterval'
+  | 'fees';
+
+export type VAnchorTotalRelayerFeeByToken = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  tokenAddress: Scalars['Bytes'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalRelayerFeeByTokenEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalRelayerFeeByTokenEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFeeByTokenEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFeeByTokenEvery15Min_filter>>>;
+};
+
+export type VAnchorTotalRelayerFeeByTokenEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'startInterval'
+  | 'endInterval'
+  | 'fees';
+
+export type VAnchorTotalRelayerFeeByToken_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFeeByToken_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFeeByToken_filter>>>;
+};
+
+export type VAnchorTotalRelayerFeeByToken_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenSymbol'
+  | 'tokenAddress'
+  | 'fees';
+
+export type VAnchorTotalRelayerFee_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFee_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalRelayerFee_filter>>>;
+};
+
+export type VAnchorTotalRelayerFee_orderBy =
+  | 'id'
+  | 'fees';
+
+export type VAnchorTotalValueLocked = {
+  id: Scalars['String'];
+  totalValueLocked: Scalars['BigInt'];
+};
+
+export type VAnchorTotalValueLockedByToken = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  totalValueLocked: Scalars['BigInt'];
+};
+
+export type VAnchorTotalValueLockedByTokenEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  totalValueLocked: Scalars['BigInt'];
+};
+
+export type VAnchorTotalValueLockedByTokenEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalValueLocked?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_not?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalValueLocked_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLockedByTokenEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLockedByTokenEvery15Min_filter>>>;
+};
+
+export type VAnchorTotalValueLockedByTokenEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'startInterval'
+  | 'endInterval'
+  | 'totalValueLocked';
+
+export type VAnchorTotalValueLockedByToken_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  totalValueLocked?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_not?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalValueLocked_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLockedByToken_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLockedByToken_filter>>>;
+};
+
+export type VAnchorTotalValueLockedByToken_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'totalValueLocked';
+
+export type VAnchorTotalValueLockedEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  totalValueLocked: Scalars['BigInt'];
+};
+
+export type VAnchorTotalValueLockedEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalValueLocked?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_not?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalValueLocked_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLockedEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLockedEvery15Min_filter>>>;
+};
+
+export type VAnchorTotalValueLockedEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'startInterval'
+  | 'endInterval'
+  | 'totalValueLocked';
+
+export type VAnchorTotalValueLocked_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  totalValueLocked?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_not?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lt?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_gte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_lte?: InputMaybe<Scalars['BigInt']>;
+  totalValueLocked_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalValueLocked_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLocked_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalValueLocked_filter>>>;
+};
+
+export type VAnchorTotalValueLocked_orderBy =
+  | 'id'
+  | 'totalValueLocked';
+
+export type VAnchorTotalWrappingFee = {
+  id: Scalars['String'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalWrappingFee15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalWrappingFee15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFee15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFee15Min_filter>>>;
+};
+
+export type VAnchorTotalWrappingFee15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'startInterval'
+  | 'endInterval'
+  | 'fees';
+
+export type VAnchorTotalWrappingFeeByToken = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  tokenAddress: Scalars['Bytes'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalWrappingFeeByTokenEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  fees: Scalars['BigInt'];
+};
+
+export type VAnchorTotalWrappingFeeByTokenEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFeeByTokenEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFeeByTokenEvery15Min_filter>>>;
+};
+
+export type VAnchorTotalWrappingFeeByTokenEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'startInterval'
+  | 'endInterval'
+  | 'fees';
+
+export type VAnchorTotalWrappingFeeByToken_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFeeByToken_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFeeByToken_filter>>>;
+};
+
+export type VAnchorTotalWrappingFeeByToken_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenSymbol'
+  | 'tokenAddress'
+  | 'fees';
+
+export type VAnchorTotalWrappingFee_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  fees?: InputMaybe<Scalars['BigInt']>;
+  fees_not?: InputMaybe<Scalars['BigInt']>;
+  fees_gt?: InputMaybe<Scalars['BigInt']>;
+  fees_lt?: InputMaybe<Scalars['BigInt']>;
+  fees_gte?: InputMaybe<Scalars['BigInt']>;
+  fees_lte?: InputMaybe<Scalars['BigInt']>;
+  fees_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  fees_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFee_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTotalWrappingFee_filter>>>;
+};
+
+export type VAnchorTotalWrappingFee_orderBy =
+  | 'id'
+  | 'fees';
+
+export type VAnchorTransferLog = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  timestamp: Scalars['BigInt'];
+};
+
+export type VAnchorTransferLog_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorTransferLog_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorTransferLog_filter>>>;
+};
+
+export type VAnchorTransferLog_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'timestamp';
+
+export type VAnchorWithdrawal = {
+  id: Scalars['String'];
+  withdrawal: Scalars['BigInt'];
+  averageWithdrawal: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorWithdrawalByToken = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  withdrawal: Scalars['BigInt'];
+  averageWithdrawal: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorWithdrawalByTokenEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  withdrawal: Scalars['BigInt'];
+  averageWithdrawal: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorWithdrawalByTokenEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalByTokenEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalByTokenEvery15Min_filter>>>;
+};
+
+export type VAnchorWithdrawalByTokenEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'startInterval'
+  | 'endInterval'
+  | 'withdrawal'
+  | 'averageWithdrawal'
+  | 'totalCount';
+
+export type VAnchorWithdrawalByToken_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  withdrawal?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalByToken_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalByToken_filter>>>;
+};
+
+export type VAnchorWithdrawalByToken_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'withdrawal'
+  | 'averageWithdrawal'
+  | 'totalCount';
+
+export type VAnchorWithdrawalEvery15Min = {
+  id: Scalars['String'];
+  vAnchorAddress: Scalars['Bytes'];
+  startInterval: Scalars['BigInt'];
+  endInterval: Scalars['BigInt'];
+  withdrawal: Scalars['BigInt'];
+  averageWithdrawal: Scalars['BigInt'];
+  totalCount: Scalars['BigInt'];
+};
+
+export type VAnchorWithdrawalEvery15Min_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  startInterval?: InputMaybe<Scalars['BigInt']>;
+  startInterval_not?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  startInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  startInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  startInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval?: InputMaybe<Scalars['BigInt']>;
+  endInterval_not?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lt?: InputMaybe<Scalars['BigInt']>;
+  endInterval_gte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_lte?: InputMaybe<Scalars['BigInt']>;
+  endInterval_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  endInterval_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalEvery15Min_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalEvery15Min_filter>>>;
+};
+
+export type VAnchorWithdrawalEvery15Min_orderBy =
+  | 'id'
+  | 'vAnchorAddress'
+  | 'startInterval'
+  | 'endInterval'
+  | 'withdrawal'
+  | 'averageWithdrawal'
+  | 'totalCount';
+
+export type VAnchorWithdrawalLog = {
+  id: Scalars['String'];
+  withdrawal: Scalars['BigInt'];
+  vAnchorAddress: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  tokenSymbol: Scalars['String'];
+  timestamp: Scalars['BigInt'];
+};
+
+export type VAnchorWithdrawalLog_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  withdrawal?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  vAnchorAddress?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  vAnchorAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  vAnchorAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenSymbol?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lt?: InputMaybe<Scalars['String']>;
+  tokenSymbol_gte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_lte?: InputMaybe<Scalars['String']>;
+  tokenSymbol_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_not_in?: InputMaybe<Array<Scalars['String']>>;
+  tokenSymbol_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with?: InputMaybe<Scalars['String']>;
+  tokenSymbol_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalLog_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorWithdrawalLog_filter>>>;
+};
+
+export type VAnchorWithdrawalLog_orderBy =
+  | 'id'
+  | 'withdrawal'
+  | 'vAnchorAddress'
+  | 'tokenAddress'
+  | 'tokenSymbol'
+  | 'timestamp';
+
+export type VAnchorWithdrawal_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  withdrawal?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  withdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  withdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_not?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lt?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_gte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_lte?: InputMaybe<Scalars['BigInt']>;
+  averageWithdrawal_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  averageWithdrawal_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount?: InputMaybe<Scalars['BigInt']>;
+  totalCount_not?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lt?: InputMaybe<Scalars['BigInt']>;
+  totalCount_gte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_lte?: InputMaybe<Scalars['BigInt']>;
+  totalCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<VAnchorWithdrawal_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<VAnchorWithdrawal_filter>>>;
+};
+
+export type VAnchorWithdrawal_orderBy =
+  | 'id'
+  | 'withdrawal'
+  | 'averageWithdrawal'
+  | 'totalCount';
+
+export type WrappingEventLog = {
+  id: Scalars['String'];
+  sender: Scalars['Bytes'];
+  recipient: Scalars['Bytes'];
+  tokenAddress: Scalars['Bytes'];
+  wrappingFee: Scalars['BigInt'];
+  afterFeeAmount: Scalars['BigInt'];
+  timestamp: Scalars['BigInt'];
+};
+
+export type WrappingEventLog_filter = {
+  id?: InputMaybe<Scalars['String']>;
+  id_not?: InputMaybe<Scalars['String']>;
+  id_gt?: InputMaybe<Scalars['String']>;
+  id_lt?: InputMaybe<Scalars['String']>;
+  id_gte?: InputMaybe<Scalars['String']>;
+  id_lte?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<Scalars['String']>>;
+  id_not_in?: InputMaybe<Array<Scalars['String']>>;
+  id_contains?: InputMaybe<Scalars['String']>;
+  id_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_not_contains?: InputMaybe<Scalars['String']>;
+  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  id_starts_with?: InputMaybe<Scalars['String']>;
+  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_starts_with?: InputMaybe<Scalars['String']>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  id_ends_with?: InputMaybe<Scalars['String']>;
+  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id_not_ends_with?: InputMaybe<Scalars['String']>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  sender?: InputMaybe<Scalars['Bytes']>;
+  sender_not?: InputMaybe<Scalars['Bytes']>;
+  sender_gt?: InputMaybe<Scalars['Bytes']>;
+  sender_lt?: InputMaybe<Scalars['Bytes']>;
+  sender_gte?: InputMaybe<Scalars['Bytes']>;
+  sender_lte?: InputMaybe<Scalars['Bytes']>;
+  sender_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  sender_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  sender_contains?: InputMaybe<Scalars['Bytes']>;
+  sender_not_contains?: InputMaybe<Scalars['Bytes']>;
+  recipient?: InputMaybe<Scalars['Bytes']>;
+  recipient_not?: InputMaybe<Scalars['Bytes']>;
+  recipient_gt?: InputMaybe<Scalars['Bytes']>;
+  recipient_lt?: InputMaybe<Scalars['Bytes']>;
+  recipient_gte?: InputMaybe<Scalars['Bytes']>;
+  recipient_lte?: InputMaybe<Scalars['Bytes']>;
+  recipient_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  recipient_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  recipient_contains?: InputMaybe<Scalars['Bytes']>;
+  recipient_not_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lt?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_gte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_lte?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  tokenAddress_contains?: InputMaybe<Scalars['Bytes']>;
+  tokenAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
+  wrappingFee?: InputMaybe<Scalars['BigInt']>;
+  wrappingFee_not?: InputMaybe<Scalars['BigInt']>;
+  wrappingFee_gt?: InputMaybe<Scalars['BigInt']>;
+  wrappingFee_lt?: InputMaybe<Scalars['BigInt']>;
+  wrappingFee_gte?: InputMaybe<Scalars['BigInt']>;
+  wrappingFee_lte?: InputMaybe<Scalars['BigInt']>;
+  wrappingFee_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  wrappingFee_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  afterFeeAmount?: InputMaybe<Scalars['BigInt']>;
+  afterFeeAmount_not?: InputMaybe<Scalars['BigInt']>;
+  afterFeeAmount_gt?: InputMaybe<Scalars['BigInt']>;
+  afterFeeAmount_lt?: InputMaybe<Scalars['BigInt']>;
+  afterFeeAmount_gte?: InputMaybe<Scalars['BigInt']>;
+  afterFeeAmount_lte?: InputMaybe<Scalars['BigInt']>;
+  afterFeeAmount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  afterFeeAmount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<WrappingEventLog_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<WrappingEventLog_filter>>>;
+};
+
+export type WrappingEventLog_orderBy =
+  | 'id'
+  | 'sender'
+  | 'recipient'
+  | 'tokenAddress'
+  | 'wrappingFee'
+  | 'afterFeeAmount'
+  | 'timestamp';
+
+export type _Block_ = {
+  /** The hash of the block */
+  hash?: Maybe<Scalars['Bytes']>;
+  /** The block number */
+  number: Scalars['Int'];
+  /** Integer representation of the timestamp stored in blocks for the chain */
+  timestamp?: Maybe<Scalars['Int']>;
+};
+
+/** The type for the top-level _meta field */
+export type _Meta_ = {
+  /**
+   * Information about a specific subgraph block. The hash of the block
+   * will be null if the _meta field has a block constraint that asks for
+   * a block number. It will be filled if the _meta field has no block constraint
+   * and therefore asks for the latest  block
+   *
+   */
+  block: _Block_;
+  /** The deployment ID */
+  deployment: Scalars['String'];
+  /** If `true`, the subgraph encountered indexing errors at some past block */
+  hasIndexingErrors: Scalars['Boolean'];
+};
+
+export type _SubgraphErrorPolicy_ =
+  /** Data will be returned even if the subgraph has indexing errors */
+  | 'allow'
+  /** If the subgraph has indexing errors, data will be omitted. The default. */
+  | 'deny';
+
+  export type QuerySdk = {
+      /** null **/
+  edgeAddition: InContextSdkMethod<Query['edgeAddition'], QueryedgeAdditionArgs, MeshContext>,
+  /** null **/
+  edgeAdditions: InContextSdkMethod<Query['edgeAdditions'], QueryedgeAdditionsArgs, MeshContext>,
+  /** null **/
+  edgeUpdate: InContextSdkMethod<Query['edgeUpdate'], QueryedgeUpdateArgs, MeshContext>,
+  /** null **/
+  edgeUpdates: InContextSdkMethod<Query['edgeUpdates'], QueryedgeUpdatesArgs, MeshContext>,
+  /** null **/
+  insertion: InContextSdkMethod<Query['insertion'], QueryinsertionArgs, MeshContext>,
+  /** null **/
+  insertions: InContextSdkMethod<Query['insertions'], QueryinsertionsArgs, MeshContext>,
+  /** null **/
+  newCommitment: InContextSdkMethod<Query['newCommitment'], QuerynewCommitmentArgs, MeshContext>,
+  /** null **/
+  newCommitments: InContextSdkMethod<Query['newCommitments'], QuerynewCommitmentsArgs, MeshContext>,
+  /** null **/
+  newNullifier: InContextSdkMethod<Query['newNullifier'], QuerynewNullifierArgs, MeshContext>,
+  /** null **/
+  newNullifiers: InContextSdkMethod<Query['newNullifiers'], QuerynewNullifiersArgs, MeshContext>,
+  /** null **/
+  publicKey: InContextSdkMethod<Query['publicKey'], QuerypublicKeyArgs, MeshContext>,
+  /** null **/
+  publicKeys: InContextSdkMethod<Query['publicKeys'], QuerypublicKeysArgs, MeshContext>,
+  /** null **/
+  token: InContextSdkMethod<Query['token'], QuerytokenArgs, MeshContext>,
+  /** null **/
+  tokens: InContextSdkMethod<Query['tokens'], QuerytokensArgs, MeshContext>,
+  /** null **/
+  externalData: InContextSdkMethod<Query['externalData'], QueryexternalDataArgs, MeshContext>,
+  /** null **/
+  externalDatas: InContextSdkMethod<Query['externalDatas'], QueryexternalDatasArgs, MeshContext>,
+  /** null **/
+  publicInputs: InContextSdkMethod<Query['publicInputs'], QuerypublicInputsArgs, MeshContext>,
+  /** null **/
+  encryptions: InContextSdkMethod<Query['encryptions'], QueryencryptionsArgs, MeshContext>,
+  /** null **/
+  shieldedTransaction: InContextSdkMethod<Query['shieldedTransaction'], QueryshieldedTransactionArgs, MeshContext>,
+  /** null **/
+  shieldedTransactions: InContextSdkMethod<Query['shieldedTransactions'], QueryshieldedTransactionsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLocked: InContextSdkMethod<Query['vanchorTotalValueLocked'], QueryvanchorTotalValueLockedArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockeds: InContextSdkMethod<Query['vanchorTotalValueLockeds'], QueryvanchorTotalValueLockedsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockedByToken: InContextSdkMethod<Query['vanchorTotalValueLockedByToken'], QueryvanchorTotalValueLockedByTokenArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockedByTokens: InContextSdkMethod<Query['vanchorTotalValueLockedByTokens'], QueryvanchorTotalValueLockedByTokensArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockedEvery15Min: InContextSdkMethod<Query['vanchorTotalValueLockedEvery15Min'], QueryvanchorTotalValueLockedEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockedEvery15Mins: InContextSdkMethod<Query['vanchorTotalValueLockedEvery15Mins'], QueryvanchorTotalValueLockedEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockedByTokenEvery15Min: InContextSdkMethod<Query['vanchorTotalValueLockedByTokenEvery15Min'], QueryvanchorTotalValueLockedByTokenEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockedByTokenEvery15Mins: InContextSdkMethod<Query['vanchorTotalValueLockedByTokenEvery15Mins'], QueryvanchorTotalValueLockedByTokenEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFee: InContextSdkMethod<Query['vanchorTotalRelayerFee'], QueryvanchorTotalRelayerFeeArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFees: InContextSdkMethod<Query['vanchorTotalRelayerFees'], QueryvanchorTotalRelayerFeesArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFeeByToken: InContextSdkMethod<Query['vanchorTotalRelayerFeeByToken'], QueryvanchorTotalRelayerFeeByTokenArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFeeByTokens: InContextSdkMethod<Query['vanchorTotalRelayerFeeByTokens'], QueryvanchorTotalRelayerFeeByTokensArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFee15Min: InContextSdkMethod<Query['vanchorTotalRelayerFee15Min'], QueryvanchorTotalRelayerFee15MinArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFee15Mins: InContextSdkMethod<Query['vanchorTotalRelayerFee15Mins'], QueryvanchorTotalRelayerFee15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFeeByTokenEvery15Min: InContextSdkMethod<Query['vanchorTotalRelayerFeeByTokenEvery15Min'], QueryvanchorTotalRelayerFeeByTokenEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFeeByTokenEvery15Mins: InContextSdkMethod<Query['vanchorTotalRelayerFeeByTokenEvery15Mins'], QueryvanchorTotalRelayerFeeByTokenEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFee: InContextSdkMethod<Query['vanchorTotalWrappingFee'], QueryvanchorTotalWrappingFeeArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFees: InContextSdkMethod<Query['vanchorTotalWrappingFees'], QueryvanchorTotalWrappingFeesArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFeeByToken: InContextSdkMethod<Query['vanchorTotalWrappingFeeByToken'], QueryvanchorTotalWrappingFeeByTokenArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFeeByTokens: InContextSdkMethod<Query['vanchorTotalWrappingFeeByTokens'], QueryvanchorTotalWrappingFeeByTokensArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFee15Min: InContextSdkMethod<Query['vanchorTotalWrappingFee15Min'], QueryvanchorTotalWrappingFee15MinArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFee15Mins: InContextSdkMethod<Query['vanchorTotalWrappingFee15Mins'], QueryvanchorTotalWrappingFee15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFeeByTokenEvery15Min: InContextSdkMethod<Query['vanchorTotalWrappingFeeByTokenEvery15Min'], QueryvanchorTotalWrappingFeeByTokenEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFeeByTokenEvery15Mins: InContextSdkMethod<Query['vanchorTotalWrappingFeeByTokenEvery15Mins'], QueryvanchorTotalWrappingFeeByTokenEvery15MinsArgs, MeshContext>,
+  /** null **/
+  wrappingEventLog: InContextSdkMethod<Query['wrappingEventLog'], QuerywrappingEventLogArgs, MeshContext>,
+  /** null **/
+  wrappingEventLogs: InContextSdkMethod<Query['wrappingEventLogs'], QuerywrappingEventLogsArgs, MeshContext>,
+  /** null **/
+  unwrappingEventLog: InContextSdkMethod<Query['unwrappingEventLog'], QueryunwrappingEventLogArgs, MeshContext>,
+  /** null **/
+  unwrappingEventLogs: InContextSdkMethod<Query['unwrappingEventLogs'], QueryunwrappingEventLogsArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalLog: InContextSdkMethod<Query['vanchorWithdrawalLog'], QueryvanchorWithdrawalLogArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalLogs: InContextSdkMethod<Query['vanchorWithdrawalLogs'], QueryvanchorWithdrawalLogsArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawal: InContextSdkMethod<Query['vanchorWithdrawal'], QueryvanchorWithdrawalArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawals: InContextSdkMethod<Query['vanchorWithdrawals'], QueryvanchorWithdrawalsArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalByToken: InContextSdkMethod<Query['vanchorWithdrawalByToken'], QueryvanchorWithdrawalByTokenArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalByTokens: InContextSdkMethod<Query['vanchorWithdrawalByTokens'], QueryvanchorWithdrawalByTokensArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalEvery15Min: InContextSdkMethod<Query['vanchorWithdrawalEvery15Min'], QueryvanchorWithdrawalEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalEvery15Mins: InContextSdkMethod<Query['vanchorWithdrawalEvery15Mins'], QueryvanchorWithdrawalEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalByTokenEvery15Min: InContextSdkMethod<Query['vanchorWithdrawalByTokenEvery15Min'], QueryvanchorWithdrawalByTokenEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalByTokenEvery15Mins: InContextSdkMethod<Query['vanchorWithdrawalByTokenEvery15Mins'], QueryvanchorWithdrawalByTokenEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorDeposit: InContextSdkMethod<Query['vanchorDeposit'], QueryvanchorDepositArgs, MeshContext>,
+  /** null **/
+  vanchorDeposits: InContextSdkMethod<Query['vanchorDeposits'], QueryvanchorDepositsArgs, MeshContext>,
+  /** null **/
+  vanchorDepositByToken: InContextSdkMethod<Query['vanchorDepositByToken'], QueryvanchorDepositByTokenArgs, MeshContext>,
+  /** null **/
+  vanchorDepositByTokens: InContextSdkMethod<Query['vanchorDepositByTokens'], QueryvanchorDepositByTokensArgs, MeshContext>,
+  /** null **/
+  vanchorDepositEvery15Min: InContextSdkMethod<Query['vanchorDepositEvery15Min'], QueryvanchorDepositEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorDepositEvery15Mins: InContextSdkMethod<Query['vanchorDepositEvery15Mins'], QueryvanchorDepositEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorDepositByTokenEvery15Min: InContextSdkMethod<Query['vanchorDepositByTokenEvery15Min'], QueryvanchorDepositByTokenEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorDepositByTokenEvery15Mins: InContextSdkMethod<Query['vanchorDepositByTokenEvery15Mins'], QueryvanchorDepositByTokenEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorDepositLog: InContextSdkMethod<Query['vanchorDepositLog'], QueryvanchorDepositLogArgs, MeshContext>,
+  /** null **/
+  vanchorDepositLogs: InContextSdkMethod<Query['vanchorDepositLogs'], QueryvanchorDepositLogsArgs, MeshContext>,
+  /** null **/
+  vanchorTransferLog: InContextSdkMethod<Query['vanchorTransferLog'], QueryvanchorTransferLogArgs, MeshContext>,
+  /** null **/
+  vanchorTransferLogs: InContextSdkMethod<Query['vanchorTransferLogs'], QueryvanchorTransferLogsArgs, MeshContext>,
+  /** Access to subgraph metadata **/
+  _meta: InContextSdkMethod<Query['_meta'], Query_metaArgs, MeshContext>
+  };
+
+  export type MutationSdk = {
+    
+  };
+
+  export type SubscriptionSdk = {
+      /** null **/
+  edgeAddition: InContextSdkMethod<Subscription['edgeAddition'], SubscriptionedgeAdditionArgs, MeshContext>,
+  /** null **/
+  edgeAdditions: InContextSdkMethod<Subscription['edgeAdditions'], SubscriptionedgeAdditionsArgs, MeshContext>,
+  /** null **/
+  edgeUpdate: InContextSdkMethod<Subscription['edgeUpdate'], SubscriptionedgeUpdateArgs, MeshContext>,
+  /** null **/
+  edgeUpdates: InContextSdkMethod<Subscription['edgeUpdates'], SubscriptionedgeUpdatesArgs, MeshContext>,
+  /** null **/
+  insertion: InContextSdkMethod<Subscription['insertion'], SubscriptioninsertionArgs, MeshContext>,
+  /** null **/
+  insertions: InContextSdkMethod<Subscription['insertions'], SubscriptioninsertionsArgs, MeshContext>,
+  /** null **/
+  newCommitment: InContextSdkMethod<Subscription['newCommitment'], SubscriptionnewCommitmentArgs, MeshContext>,
+  /** null **/
+  newCommitments: InContextSdkMethod<Subscription['newCommitments'], SubscriptionnewCommitmentsArgs, MeshContext>,
+  /** null **/
+  newNullifier: InContextSdkMethod<Subscription['newNullifier'], SubscriptionnewNullifierArgs, MeshContext>,
+  /** null **/
+  newNullifiers: InContextSdkMethod<Subscription['newNullifiers'], SubscriptionnewNullifiersArgs, MeshContext>,
+  /** null **/
+  publicKey: InContextSdkMethod<Subscription['publicKey'], SubscriptionpublicKeyArgs, MeshContext>,
+  /** null **/
+  publicKeys: InContextSdkMethod<Subscription['publicKeys'], SubscriptionpublicKeysArgs, MeshContext>,
+  /** null **/
+  token: InContextSdkMethod<Subscription['token'], SubscriptiontokenArgs, MeshContext>,
+  /** null **/
+  tokens: InContextSdkMethod<Subscription['tokens'], SubscriptiontokensArgs, MeshContext>,
+  /** null **/
+  externalData: InContextSdkMethod<Subscription['externalData'], SubscriptionexternalDataArgs, MeshContext>,
+  /** null **/
+  externalDatas: InContextSdkMethod<Subscription['externalDatas'], SubscriptionexternalDatasArgs, MeshContext>,
+  /** null **/
+  publicInputs: InContextSdkMethod<Subscription['publicInputs'], SubscriptionpublicInputsArgs, MeshContext>,
+  /** null **/
+  encryptions: InContextSdkMethod<Subscription['encryptions'], SubscriptionencryptionsArgs, MeshContext>,
+  /** null **/
+  shieldedTransaction: InContextSdkMethod<Subscription['shieldedTransaction'], SubscriptionshieldedTransactionArgs, MeshContext>,
+  /** null **/
+  shieldedTransactions: InContextSdkMethod<Subscription['shieldedTransactions'], SubscriptionshieldedTransactionsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLocked: InContextSdkMethod<Subscription['vanchorTotalValueLocked'], SubscriptionvanchorTotalValueLockedArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockeds: InContextSdkMethod<Subscription['vanchorTotalValueLockeds'], SubscriptionvanchorTotalValueLockedsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockedByToken: InContextSdkMethod<Subscription['vanchorTotalValueLockedByToken'], SubscriptionvanchorTotalValueLockedByTokenArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockedByTokens: InContextSdkMethod<Subscription['vanchorTotalValueLockedByTokens'], SubscriptionvanchorTotalValueLockedByTokensArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockedEvery15Min: InContextSdkMethod<Subscription['vanchorTotalValueLockedEvery15Min'], SubscriptionvanchorTotalValueLockedEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockedEvery15Mins: InContextSdkMethod<Subscription['vanchorTotalValueLockedEvery15Mins'], SubscriptionvanchorTotalValueLockedEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockedByTokenEvery15Min: InContextSdkMethod<Subscription['vanchorTotalValueLockedByTokenEvery15Min'], SubscriptionvanchorTotalValueLockedByTokenEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorTotalValueLockedByTokenEvery15Mins: InContextSdkMethod<Subscription['vanchorTotalValueLockedByTokenEvery15Mins'], SubscriptionvanchorTotalValueLockedByTokenEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFee: InContextSdkMethod<Subscription['vanchorTotalRelayerFee'], SubscriptionvanchorTotalRelayerFeeArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFees: InContextSdkMethod<Subscription['vanchorTotalRelayerFees'], SubscriptionvanchorTotalRelayerFeesArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFeeByToken: InContextSdkMethod<Subscription['vanchorTotalRelayerFeeByToken'], SubscriptionvanchorTotalRelayerFeeByTokenArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFeeByTokens: InContextSdkMethod<Subscription['vanchorTotalRelayerFeeByTokens'], SubscriptionvanchorTotalRelayerFeeByTokensArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFee15Min: InContextSdkMethod<Subscription['vanchorTotalRelayerFee15Min'], SubscriptionvanchorTotalRelayerFee15MinArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFee15Mins: InContextSdkMethod<Subscription['vanchorTotalRelayerFee15Mins'], SubscriptionvanchorTotalRelayerFee15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFeeByTokenEvery15Min: InContextSdkMethod<Subscription['vanchorTotalRelayerFeeByTokenEvery15Min'], SubscriptionvanchorTotalRelayerFeeByTokenEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorTotalRelayerFeeByTokenEvery15Mins: InContextSdkMethod<Subscription['vanchorTotalRelayerFeeByTokenEvery15Mins'], SubscriptionvanchorTotalRelayerFeeByTokenEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFee: InContextSdkMethod<Subscription['vanchorTotalWrappingFee'], SubscriptionvanchorTotalWrappingFeeArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFees: InContextSdkMethod<Subscription['vanchorTotalWrappingFees'], SubscriptionvanchorTotalWrappingFeesArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFeeByToken: InContextSdkMethod<Subscription['vanchorTotalWrappingFeeByToken'], SubscriptionvanchorTotalWrappingFeeByTokenArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFeeByTokens: InContextSdkMethod<Subscription['vanchorTotalWrappingFeeByTokens'], SubscriptionvanchorTotalWrappingFeeByTokensArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFee15Min: InContextSdkMethod<Subscription['vanchorTotalWrappingFee15Min'], SubscriptionvanchorTotalWrappingFee15MinArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFee15Mins: InContextSdkMethod<Subscription['vanchorTotalWrappingFee15Mins'], SubscriptionvanchorTotalWrappingFee15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFeeByTokenEvery15Min: InContextSdkMethod<Subscription['vanchorTotalWrappingFeeByTokenEvery15Min'], SubscriptionvanchorTotalWrappingFeeByTokenEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorTotalWrappingFeeByTokenEvery15Mins: InContextSdkMethod<Subscription['vanchorTotalWrappingFeeByTokenEvery15Mins'], SubscriptionvanchorTotalWrappingFeeByTokenEvery15MinsArgs, MeshContext>,
+  /** null **/
+  wrappingEventLog: InContextSdkMethod<Subscription['wrappingEventLog'], SubscriptionwrappingEventLogArgs, MeshContext>,
+  /** null **/
+  wrappingEventLogs: InContextSdkMethod<Subscription['wrappingEventLogs'], SubscriptionwrappingEventLogsArgs, MeshContext>,
+  /** null **/
+  unwrappingEventLog: InContextSdkMethod<Subscription['unwrappingEventLog'], SubscriptionunwrappingEventLogArgs, MeshContext>,
+  /** null **/
+  unwrappingEventLogs: InContextSdkMethod<Subscription['unwrappingEventLogs'], SubscriptionunwrappingEventLogsArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalLog: InContextSdkMethod<Subscription['vanchorWithdrawalLog'], SubscriptionvanchorWithdrawalLogArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalLogs: InContextSdkMethod<Subscription['vanchorWithdrawalLogs'], SubscriptionvanchorWithdrawalLogsArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawal: InContextSdkMethod<Subscription['vanchorWithdrawal'], SubscriptionvanchorWithdrawalArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawals: InContextSdkMethod<Subscription['vanchorWithdrawals'], SubscriptionvanchorWithdrawalsArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalByToken: InContextSdkMethod<Subscription['vanchorWithdrawalByToken'], SubscriptionvanchorWithdrawalByTokenArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalByTokens: InContextSdkMethod<Subscription['vanchorWithdrawalByTokens'], SubscriptionvanchorWithdrawalByTokensArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalEvery15Min: InContextSdkMethod<Subscription['vanchorWithdrawalEvery15Min'], SubscriptionvanchorWithdrawalEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalEvery15Mins: InContextSdkMethod<Subscription['vanchorWithdrawalEvery15Mins'], SubscriptionvanchorWithdrawalEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalByTokenEvery15Min: InContextSdkMethod<Subscription['vanchorWithdrawalByTokenEvery15Min'], SubscriptionvanchorWithdrawalByTokenEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorWithdrawalByTokenEvery15Mins: InContextSdkMethod<Subscription['vanchorWithdrawalByTokenEvery15Mins'], SubscriptionvanchorWithdrawalByTokenEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorDeposit: InContextSdkMethod<Subscription['vanchorDeposit'], SubscriptionvanchorDepositArgs, MeshContext>,
+  /** null **/
+  vanchorDeposits: InContextSdkMethod<Subscription['vanchorDeposits'], SubscriptionvanchorDepositsArgs, MeshContext>,
+  /** null **/
+  vanchorDepositByToken: InContextSdkMethod<Subscription['vanchorDepositByToken'], SubscriptionvanchorDepositByTokenArgs, MeshContext>,
+  /** null **/
+  vanchorDepositByTokens: InContextSdkMethod<Subscription['vanchorDepositByTokens'], SubscriptionvanchorDepositByTokensArgs, MeshContext>,
+  /** null **/
+  vanchorDepositEvery15Min: InContextSdkMethod<Subscription['vanchorDepositEvery15Min'], SubscriptionvanchorDepositEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorDepositEvery15Mins: InContextSdkMethod<Subscription['vanchorDepositEvery15Mins'], SubscriptionvanchorDepositEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorDepositByTokenEvery15Min: InContextSdkMethod<Subscription['vanchorDepositByTokenEvery15Min'], SubscriptionvanchorDepositByTokenEvery15MinArgs, MeshContext>,
+  /** null **/
+  vanchorDepositByTokenEvery15Mins: InContextSdkMethod<Subscription['vanchorDepositByTokenEvery15Mins'], SubscriptionvanchorDepositByTokenEvery15MinsArgs, MeshContext>,
+  /** null **/
+  vanchorDepositLog: InContextSdkMethod<Subscription['vanchorDepositLog'], SubscriptionvanchorDepositLogArgs, MeshContext>,
+  /** null **/
+  vanchorDepositLogs: InContextSdkMethod<Subscription['vanchorDepositLogs'], SubscriptionvanchorDepositLogsArgs, MeshContext>,
+  /** null **/
+  vanchorTransferLog: InContextSdkMethod<Subscription['vanchorTransferLog'], SubscriptionvanchorTransferLogArgs, MeshContext>,
+  /** null **/
+  vanchorTransferLogs: InContextSdkMethod<Subscription['vanchorTransferLogs'], SubscriptionvanchorTransferLogsArgs, MeshContext>,
+  /** Access to subgraph metadata **/
+  _meta: InContextSdkMethod<Subscription['_meta'], Subscription_metaArgs, MeshContext>
+  };
+
+  export type Context = {
+      ["vanchor"]: { Query: QuerySdk, Mutation: MutationSdk, Subscription: SubscriptionSdk },
+      ["subgraphUrl"]: Scalars['ID']
+    };
+}

--- a/packages/vanchor/configs/chains.prod.toml
+++ b/packages/vanchor/configs/chains.prod.toml
@@ -18,10 +18,6 @@ provider = [{ label = "hermes", url = "https://hermes-testnet.webb.tools", featu
 shard = "primary"
 provider = [{ label = "demeter", url = "https://demeter-testnet.webb.tools", features= ["archive", "traces"]}]
 
-# [chains.Sepolia]
-# shard = "primary"
-# provider = [{ label = "sepolia", url = "https://sepolia.infura.io/v3/90de850aff68424ab8e7321017406586", features= []}]
-
 [deployment]
 shard = "primary"
 [[deployment.rule]]

--- a/packages/vanchor/networks/live.json
+++ b/packages/vanchor/networks/live.json
@@ -1,10 +1,4 @@
 {
-  "sepolia": {
-    "vanchor": {
-      "address": "0x91eB86019FD8D7c5a9E31143D422850A13F670A3",
-      "startBlock": 0
-    }
-  },
   "Athena": {
     "vanchor": {
       "address": "0xDa68464c391Da8ff60b40273F2Ef0a9971694F99",


### PR DESCRIPTION
### Summary of changes

- Regenerate the `.graphclient` directory for building and publishing because we don't have a live endpoint to generate it from.
- Remove `Sepolia` as we don't need it now.