### PR TITLE
Fixes proposal type null error in dkgProposalEventHandler

### DIFF
--- a/packages/dkg/project.yaml
+++ b/packages/dkg/project.yaml
@@ -18,7 +18,7 @@ schema:
 
 network:
   # Use Tangle network endpoint for Arana Alpha testnet see: https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fstats-dev.api.webb.tools%2Fpublic-ws#/settings/metadata
-  chainId: '0xbb3a6994c7a2c9512220cac600fca8ccaa8bcc018a0e93467a2d63971b598a23'
+  chainId: '0xea63e6ac7da8699520af7fb540470d63e48eccb33f7273d2e21a935685bf1320'
   # using testnet archive node endpoint
   endpoint: 'wss://tangle-standalone-archive.webb.tools'
   # if you are using docker, uncomment the below line
@@ -28,7 +28,7 @@ network:
 
 dataSources:
   - kind: substrate/Runtime
-    startBlock: 1
+    startBlock: 57400
     mapping:
       file: ./dist/index.js
       handlers:

--- a/packages/dkg/src/handlers/dkg/dkgProposals/eventHandler.ts
+++ b/packages/dkg/src/handlers/dkg/dkgProposals/eventHandler.ts
@@ -48,7 +48,7 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
         );
         const blockNumber = eventDecoder.blockNumber;
         const timestamp = (await Block.get(blockNumber)).timestamp;
-        const proposalType = getProposalType(eventData.kind + 'Proposal');
+        const proposalType = getProposalType({ type: eventData.kind + 'Proposal' });
         const proposerWithVote = {
           proposer: eventData.who.toString(),
           vote: ProposalVoteType.For,
@@ -75,7 +75,7 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
         );
         const blockNumber = eventDecoder.blockNumber;
         const timestamp = (await Block.get(blockNumber)).timestamp;
-        const proposalType = getProposalType(eventData.kind + 'Proposal');
+        const proposalType = getProposalType({ type: eventData.kind + 'Proposal' });
         const proposerWithVote = {
           proposer: eventData.who.toString(),
           vote: ProposalVoteType.Against,
@@ -102,7 +102,7 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
         );
         const blockNumber = eventDecoder.blockNumber;
         const timestamp = (await Block.get(blockNumber)).timestamp;
-        const proposalType = getProposalType(eventData.kind + 'Proposal');
+        const proposalType = getProposalType({ type: eventData.kind + 'Proposal' });
         const approvedTimeline = {
           status: ProposalTimelineStatus.Approved,
           timestamp: timestamp,
@@ -129,7 +129,7 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
         );
         const blockNumber = eventDecoder.blockNumber;
         const timestamp = (await Block.get(blockNumber)).timestamp;
-        const proposalType = getProposalType(eventData.kind + 'Proposal');
+        const proposalType = getProposalType({ type: eventData.kind + 'Proposal' });
         const rejectedTimeline = {
           status: ProposalTimelineStatus.Rejected,
           timestamp: timestamp,
@@ -156,7 +156,7 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
         );
         const blockNumber = eventDecoder.blockNumber;
         const timestamp = (await Block.get(blockNumber)).timestamp;
-        const proposalType = getProposalType(eventData.kind + 'Proposal');
+        const proposalType = getProposalType({ type: eventData.kind + 'Proposal' });
         const succeededTimeline = {
           status: ProposalTimelineStatus.Succeeded,
           timestamp: timestamp,
@@ -183,7 +183,7 @@ export async function dkgProposalEventHandler(event: SubstrateEvent) {
         );
         const blockNumber = eventDecoder.blockNumber;
         const timestamp = (await Block.get(blockNumber)).timestamp;
-        const proposalType = getProposalType(eventData.kind + 'Proposal');
+        const proposalType = getProposalType({ type: eventData.kind + 'Proposal' });
         const failedTimeline = {
           status: ProposalTimelineStatus.Failed,
           timestamp: timestamp,


### PR DESCRIPTION
### Overview
Fixes proposal type null error in dkgProposalEventHandler by passing proposal type as an object to the method `getProposalType` instead of directly passing the proposal type.

Closes #126 

https://github.com/webb-tools/webb-graphql/assets/53374218/7d0a0a6a-f6d9-4648-be62-03458102b4fc