### PR TITLE
Add Relayer profit and txFees fields

### DIFF
--- a/packages/vanchor-client/src/graphql/relayerFee.graphql
+++ b/packages/vanchor-client/src/graphql/relayerFee.graphql
@@ -1,6 +1,8 @@
 query GetVAnchorTotalRelayerFee($vAnchorAddress: ID!) {
   vanchorTotalRelayerFee(id: $vAnchorAddress) {
     fees
+    txFees
+    profit
   }
 }
 
@@ -8,6 +10,8 @@ query GetVAnchorsTotalRelayerFees($vAnchorAddresses: [String!]!) {
   vanchorTotalRelayerFees(where: { id_in: $vAnchorAddresses }) {
     id
     fees
+    txFees
+    profit
   }
 }
 
@@ -20,6 +24,8 @@ query GetVAnchorTotalRelayerFeeByTokens(
     where: { tokenSymbol: $tokenSymbol, vAnchorAddress: $vAnchorAddress }
   ) {
     fees
+    txFees
+    profit
   }
 }
 
@@ -37,6 +43,8 @@ query GetVAnchorRelayerFeeEvery15Mins(
   ) {
     startInterval
     fees
+    txFees
+    profit
     vAnchorAddress
     endInterval
   }
@@ -57,6 +65,8 @@ query GetVAnchorsRelayerFeeEvery15Mins(
     id
     startInterval
     fees
+    txFees
+    profit
     endInterval
     vAnchorAddress
   }
@@ -77,6 +87,8 @@ query GetVAnchorRelayerFeeByTokenEvery15Mins(
     }
   ) {
     fees
+    txFees
+    profit
     startInterval
     endInterval
     vAnchorAddress

--- a/packages/vanchor/schema.graphql
+++ b/packages/vanchor/schema.graphql
@@ -158,7 +158,9 @@ type VAnchorTotalValueLockedByTokenEveryDay @entity(immutable: false) {
 
 type VAnchorTotalRelayerFee @entity(immutable: false) {
   id: String! # vAnchor address
-  fees: BigInt! # total value locked in the vAnchor
+  fees: BigInt! # Total Fees (txFee + relayerProfit)
+  txFees: BigInt! # Network Fees
+  profit: BigInt! # Relayer's Profit
 }
 
 type VAnchorTotalRelayerFeeByToken @entity(immutable: false) {
@@ -166,7 +168,9 @@ type VAnchorTotalRelayerFeeByToken @entity(immutable: false) {
   vAnchorAddress: Bytes! # address
   tokenSymbol: String! # token symbol
   tokenAddress: Bytes! # address
-  fees: BigInt! # total value locked in the vAnchor
+  fees: BigInt! # Total Fees (txFee + relayerProfit)
+  txFees: BigInt! # Network Fees
+  profit: BigInt! # Relayer's Profit
 }
 
 type VAnchorTotalRelayerFee15Min @entity(immutable: false) {
@@ -174,7 +178,9 @@ type VAnchorTotalRelayerFee15Min @entity(immutable: false) {
   vAnchorAddress: Bytes! # address
   startInterval: BigInt! # start time of the interval
   endInterval: BigInt! # end time of the interval
-  fees: BigInt! # total value locked in the vAnchor
+  fees: BigInt! # Total Fees (txFee + relayerProfit)
+  txFees: BigInt! # Network Fees
+  profit: BigInt! # Relayer's Profit
 }
 
 type VAnchorTotalRelayerFeeByTokenEvery15Min @entity(immutable: false) {
@@ -184,7 +190,9 @@ type VAnchorTotalRelayerFeeByTokenEvery15Min @entity(immutable: false) {
   tokenSymbol: String! # token symbol
   startInterval: BigInt! # start time of the interval
   endInterval: BigInt! # end time of the interval
-  fees: BigInt! # total value locked in the vAnchor
+  fees: BigInt! # Total Fees (txFee + relayerProfit)
+  txFees: BigInt! # Network Fees
+  profit: BigInt! # Relayer's Profit
 }
 
 type VAnchorTotalWrappingFee @entity(immutable: false) {
@@ -395,7 +403,7 @@ type VAnchorVolumeByToken @entity(immutable: false) {
   vAnchorAddress: Bytes! # address
   tokenAddress: Bytes! # address
   tokenSymbol: String! # token symbol
-  volume: BigInt! 
+  volume: BigInt!
 }
 
 type VAnchorVolumeEvery15Min @entity(immutable: false) {
@@ -403,7 +411,7 @@ type VAnchorVolumeEvery15Min @entity(immutable: false) {
   vAnchorAddress: Bytes! # address
   startInterval: BigInt! # start time of the interval
   endInterval: BigInt! # end time of the interval
-  volume: BigInt! 
+  volume: BigInt!
 }
 
 type VAnchorVolumeByTokenEvery15Min @entity(immutable: false) {
@@ -413,7 +421,7 @@ type VAnchorVolumeByTokenEvery15Min @entity(immutable: false) {
   tokenSymbol: String! # token symbol
   startInterval: BigInt! # start time of the interval
   endInterval: BigInt! # end time of the interval
-  volume: BigInt! 
+  volume: BigInt!
 }
 
 type VAnchorVolumeEveryDay @entity(immutable: false) {

--- a/packages/vanchor/src/relayerFees/relayerFees.ts
+++ b/packages/vanchor/src/relayerFees/relayerFees.ts
@@ -8,7 +8,8 @@ import { getTokenSymbol } from '../token';
 export default function recordRelayerFees(
   vAnchorAddress: Bytes,
   tokenAddress: Bytes,
-  fee: BigInt
+  fees: BigInt,
+  txFees: BigInt
 ): void {
   const id = vAnchorAddress.toHexString() + '-' + tokenAddress.toHexString();
   const vanchorTotalValueLockedByToken = VAnchorTotalRelayerFeeByToken.load(id);
@@ -17,7 +18,9 @@ export default function recordRelayerFees(
     const newVanchorTotalValueLockedByToken = new VAnchorTotalRelayerFeeByToken(
       id
     );
-    newVanchorTotalValueLockedByToken.fees = fee;
+    newVanchorTotalValueLockedByToken.fees = fees;
+    newVanchorTotalValueLockedByToken.txFees = txFees;
+    newVanchorTotalValueLockedByToken.profit = fees.minus(txFees);
     newVanchorTotalValueLockedByToken.vAnchorAddress = vAnchorAddress;
     newVanchorTotalValueLockedByToken.tokenSymbol =
       getTokenSymbol(tokenAddress);
@@ -25,7 +28,11 @@ export default function recordRelayerFees(
     newVanchorTotalValueLockedByToken.save();
   } else {
     vanchorTotalValueLockedByToken.fees =
-      vanchorTotalValueLockedByToken.fees.plus(fee);
+      vanchorTotalValueLockedByToken.fees.plus(fees);
+    vanchorTotalValueLockedByToken.txFees =
+      vanchorTotalValueLockedByToken.txFees.plus(txFees);
+    vanchorTotalValueLockedByToken.profit =
+      vanchorTotalValueLockedByToken.profit.plus(fees.minus(txFees));
     vanchorTotalValueLockedByToken.save();
   }
 
@@ -38,10 +45,17 @@ export default function recordRelayerFees(
     const newVanchorTotalValueLocked = new VAnchorTotalRelayerFee(
       vAnchorAddress.toHexString()
     );
-    newVanchorTotalValueLocked.fees = fee;
+    newVanchorTotalValueLocked.fees = fees;
+    newVanchorTotalValueLocked.txFees = txFees;
+    newVanchorTotalValueLocked.profit = fees.minus(txFees);
     newVanchorTotalValueLocked.save();
   } else {
-    vanchorTotalValueLocked.fees = vanchorTotalValueLocked.fees.plus(fee);
+    vanchorTotalValueLocked.fees = vanchorTotalValueLocked.fees.plus(fees);
+    vanchorTotalValueLocked.txFees =
+      vanchorTotalValueLocked.txFees.plus(txFees);
+    vanchorTotalValueLocked.profit = vanchorTotalValueLocked.profit.plus(
+      fees.minus(txFees)
+    );
     vanchorTotalValueLocked.save();
   }
 }

--- a/packages/vanchor/src/relayerFees/relayerFees15MinsInterval.ts
+++ b/packages/vanchor/src/relayerFees/relayerFees15MinsInterval.ts
@@ -10,6 +10,7 @@ export default function recordRelayerFees15MinsInterval(
   vAnchorAddress: Bytes,
   tokenAddress: Bytes,
   fees: BigInt,
+  txFees: BigInt,
   time: BigInt
 ): void {
   const startInterval = getStartInterval15Mins(time);
@@ -28,6 +29,8 @@ export default function recordRelayerFees15MinsInterval(
       id
     );
     newVanchorFeeByToken.fees = fees;
+    newVanchorFeeByToken.txFees = txFees;
+    newVanchorFeeByToken.profit = fees.minus(txFees);
     newVanchorFeeByToken.vAnchorAddress = vAnchorAddress;
     newVanchorFeeByToken.tokenSymbol = getTokenSymbol(tokenAddress);
     newVanchorFeeByToken.tokenAddress = tokenAddress;
@@ -40,6 +43,10 @@ export default function recordRelayerFees15MinsInterval(
     newVanchorFeeByToken.save();
   } else {
     vanchorFeeByToken.fees = vanchorFeeByToken.fees.plus(fees);
+    vanchorFeeByToken.txFees = vanchorFeeByToken.txFees.plus(txFees);
+    vanchorFeeByToken.profit = vanchorFeeByToken.profit.plus(
+      fees.minus(txFees)
+    );
     vanchorFeeByToken.save();
   }
 
@@ -54,9 +61,13 @@ export default function recordRelayerFees15MinsInterval(
     newVanchorFee.endInterval = BigInt.fromString(endInterval.toString());
     newVanchorFee.vAnchorAddress = vAnchorAddress;
     newVanchorFee.fees = fees;
+    newVanchorFee.txFees = txFees;
+    newVanchorFee.profit = fees.minus(txFees);
     newVanchorFee.save();
   } else {
     vanchorFee.fees = vanchorFee.fees.plus(fees);
+    vanchorFee.txFees = vanchorFee.txFees.plus(txFees);
+    vanchorFee.profit = vanchorFee.profit.plus(fees.minus(txFees));
     vanchorFee.save();
   }
 }

--- a/packages/vanchor/subgraph.yaml
+++ b/packages/vanchor/subgraph.yaml
@@ -7,7 +7,7 @@ dataSources:
     network: Demeter
     source:
       abi: FungibleTokenWrapper
-      address: "0xbfce6B877Ebff977bB6e80B24FbBb7bC4eBcA4df"
+      address: "0x58BA29259Aab901179A07899235e3CB88afE9079"
       startBlock: 0
     mapping:
       kind: ethereum/events
@@ -38,7 +38,7 @@ dataSources:
     network: Demeter
     source:
       abi: VAnchor
-      address: "0x91eB86019FD8D7c5a9E31143D422850A13F670A3"
+      address: "0x7aA556dD0AF8bed063444E14A6A9af46C9266973"
       startBlock: 0
     mapping:
       kind: ethereum/events


### PR DESCRIPTION
## Overview

This proposal aims to enhance the frontend of the stats dApp by introducing two new fields, namely `txFees` and net `profit`, to the Relayer Fees. The primary motivation behind this modification is the inadequacy of the existing `fees` field in the `ExternalData` to accurately represent the actual profit earned by relayers. This limitation arises due to various factors, with the main reason being that the `fees` value is calculated as follows:

```math
txFees = gasUsed * gasPrice
```

```math
profit = txFees + (txFees * X\%)
```

```math
fees = txFees + profit
```

To address this issue, it is necessary to visually present the separate values of `txFees` and `profit` in the user interface (UI) to clarify that the `fees` value does not indicate the net profit earned by relayers.

## Notes

It is important to note that the `fees` value represents the amount of wrapped tokens that the smart contract will provide to the relayer for their services. However, since this value is not in the native token, it cannot always be assumed that $`profit = fees - txFees`$. Therefore, it may be necessary to display `txFees` and `profit` as distinct entities in the UI.