### PR TITLE
Changes proposal batch block number type

### DIFF
--- a/packages/dkg/schema.graphql
+++ b/packages/dkg/schema.graphql
@@ -287,7 +287,7 @@ type Proposal @entity {
 
 type ProposalBatch @entity {
   id: ID!
-  blockNumber: String!
+  blockNumber: Int!
   timestamp: Date!
   status: ProposalBatchStatus!
   proposals: [ProposalInABatch]!

--- a/packages/dkg/src/handlers/dkg/dkgMetaData/publicKey.ts
+++ b/packages/dkg/src/handlers/dkg/dkgMetaData/publicKey.ts
@@ -30,10 +30,7 @@ export async function ensureKey(data: PublicKeyGenerated) {
       ex.arguments.indexOf(data.composedPubKey) > -1
     );
   });
-  let txHash = '';
-  if (matcheExtrinsic) {
-    txHash = matcheExtrinsic.hash;
-  }
+  const hash = await api.rpc.chain.getBlockHash(data.blockNumber);
   const newKey = PublicKey.create({
     blockId: data.blockNumber,
     id: data.composedPubKey,
@@ -42,7 +39,7 @@ export async function ensureKey(data: PublicKeyGenerated) {
       {
         stage: SessionKeyStatus.Generated,
         blockNumber: data.blockNumber,
-        txHash,
+        txHash: hash.toString(),
         timestamp: data.timestamp,
       },
     ],

--- a/packages/dkg/src/utils/proposals/getCurrentQueues.ts
+++ b/packages/dkg/src/utils/proposals/getCurrentQueues.ts
@@ -92,7 +92,7 @@ export const updateProposalBatch = async (proposalBatchToUpdate: UpdateProposalB
     proposalBatch = new ProposalBatch(id);
   }
 
-  proposalBatch.blockNumber = blockNumber ? blockNumber : '';
+  proposalBatch.blockNumber = blockNumber ? Number(blockNumber) : 0;
   proposalBatch.timestamp = timestamp ? timestamp : new Date();
   proposalBatch.status = status ? status : ProposalBatchStatus.Unknown;
   proposalBatch.proposals = proposals ? proposals : [];


### PR DESCRIPTION
### Overview

- Updates proposal batch block number type to `Int` - for correct ordering of batched proposals to show in `stats-dapp` proposals page.
- Updates public key txn hash to block hash.

Note:

Changing `txn hash` to `block hash` is a temporary fix and ideally in `stats-dapp`'s `key detail` page we should show both `txn hash` and `block hash`. By making this update, when user clicks on the block hash we can send them to view the block in polkadot explorer.