### PR TITLE
Add queries to get the lastest tvl data based on given time range

### DIFF
--- a/packages/vanchor-client/.graphclient/index.ts
+++ b/packages/vanchor-client/.graphclient/index.ts
@@ -9622,11 +9622,11 @@ const merger = new(BareMerger as any)({
         },
         location: 'GetVAnchorsTotalValueLockedByDateRangeDocument.graphql'
       },{
-        document: GetVAnchorLatestTvlInTimeRangeDocument,
+        document: GetVAnchorLatestTvlItemInTimeRangeDocument,
         get rawSDL() {
-          return printWithCache(GetVAnchorLatestTvlInTimeRangeDocument);
+          return printWithCache(GetVAnchorLatestTvlItemInTimeRangeDocument);
         },
-        location: 'GetVAnchorLatestTvlInTimeRangeDocument.graphql'
+        location: 'GetVAnchorLatestTvlItemInTimeRangeDocument.graphql'
       },{
         document: GetVAnchorTwlDocument,
         get rawSDL() {
@@ -10219,14 +10219,14 @@ export type GetVAnchorsTotalValueLockedByDateRangeQueryVariables = Exact<{
 
 export type GetVAnchorsTotalValueLockedByDateRangeQuery = { vanchorTotalValueLockedEveryDays: Array<Pick<VAnchorTotalValueLockedEveryDay, 'totalValueLocked' | 'vAnchorAddress' | 'startInterval' | 'endInterval'>> };
 
-export type GetVAnchorLatestTVLInTimeRangeQueryVariables = Exact<{
+export type GetVAnchorLatestTVLItemInTimeRangeQueryVariables = Exact<{
   endInterval: Scalars['BigInt'];
   startInterval: Scalars['BigInt'];
   vAnchorAddress: Scalars['Bytes'];
 }>;
 
 
-export type GetVAnchorLatestTVLInTimeRangeQuery = { vanchorTotalValueLockedEvery15Mins: Array<Pick<VAnchorTotalValueLockedEvery15Min, 'totalValueLocked'>> };
+export type GetVAnchorLatestTVLItemInTimeRangeQuery = { vanchorTotalValueLockedEvery15Mins: Array<Pick<VAnchorTotalValueLockedEvery15Min, 'totalValueLocked'>> };
 
 export type GetVAnchorTWLQueryVariables = Exact<{
   vAnchorAddress: Scalars['ID'];
@@ -11018,8 +11018,8 @@ export const GetVAnchorsTotalValueLockedByDateRangeDocument = gql`
   }
 }
     ` as unknown as DocumentNode<GetVAnchorsTotalValueLockedByDateRangeQuery, GetVAnchorsTotalValueLockedByDateRangeQueryVariables>;
-export const GetVAnchorLatestTVLInTimeRangeDocument = gql`
-    query GetVAnchorLatestTVLInTimeRange($endInterval: BigInt!, $startInterval: BigInt!, $vAnchorAddress: Bytes!) {
+export const GetVAnchorLatestTVLItemInTimeRangeDocument = gql`
+    query GetVAnchorLatestTVLItemInTimeRange($endInterval: BigInt!, $startInterval: BigInt!, $vAnchorAddress: Bytes!) {
   vanchorTotalValueLockedEvery15Mins(
     orderBy: endInterval
     orderDirection: desc
@@ -11029,7 +11029,7 @@ export const GetVAnchorLatestTVLInTimeRangeDocument = gql`
     totalValueLocked
   }
 }
-    ` as unknown as DocumentNode<GetVAnchorLatestTVLInTimeRangeQuery, GetVAnchorLatestTVLInTimeRangeQueryVariables>;
+    ` as unknown as DocumentNode<GetVAnchorLatestTVLItemInTimeRangeQuery, GetVAnchorLatestTVLItemInTimeRangeQueryVariables>;
 export const GetVAnchorTWLDocument = gql`
     query GetVAnchorTWL($vAnchorAddress: ID!) {
   vanchorTWL(id: $vAnchorAddress) {
@@ -11715,8 +11715,8 @@ export function getSdk<C, E>(requester: Requester<C, E>) {
     GetVAnchorsTotalValueLockedByDateRange(variables: GetVAnchorsTotalValueLockedByDateRangeQueryVariables, options?: C): Promise<GetVAnchorsTotalValueLockedByDateRangeQuery> {
       return requester<GetVAnchorsTotalValueLockedByDateRangeQuery, GetVAnchorsTotalValueLockedByDateRangeQueryVariables>(GetVAnchorsTotalValueLockedByDateRangeDocument, variables, options) as Promise<GetVAnchorsTotalValueLockedByDateRangeQuery>;
     },
-    GetVAnchorLatestTVLInTimeRange(variables: GetVAnchorLatestTVLInTimeRangeQueryVariables, options?: C): Promise<GetVAnchorLatestTVLInTimeRangeQuery> {
-      return requester<GetVAnchorLatestTVLInTimeRangeQuery, GetVAnchorLatestTVLInTimeRangeQueryVariables>(GetVAnchorLatestTVLInTimeRangeDocument, variables, options) as Promise<GetVAnchorLatestTVLInTimeRangeQuery>;
+    GetVAnchorLatestTVLItemInTimeRange(variables: GetVAnchorLatestTVLItemInTimeRangeQueryVariables, options?: C): Promise<GetVAnchorLatestTVLItemInTimeRangeQuery> {
+      return requester<GetVAnchorLatestTVLItemInTimeRangeQuery, GetVAnchorLatestTVLItemInTimeRangeQueryVariables>(GetVAnchorLatestTVLItemInTimeRangeDocument, variables, options) as Promise<GetVAnchorLatestTVLItemInTimeRangeQuery>;
     },
     GetVAnchorTWL(variables: GetVAnchorTWLQueryVariables, options?: C): Promise<GetVAnchorTWLQuery> {
       return requester<GetVAnchorTWLQuery, GetVAnchorTWLQueryVariables>(GetVAnchorTWLDocument, variables, options) as Promise<GetVAnchorTWLQuery>;

--- a/packages/vanchor-client/.graphclient/index.ts
+++ b/packages/vanchor-client/.graphclient/index.ts
@@ -42,6 +42,7 @@ export type Scalars = {
   BigDecimal: any;
   BigInt: any;
   Bytes: any;
+  Int8: any;
 };
 
 export type Query = {
@@ -8065,6 +8066,7 @@ export type ResolversTypes = ResolversObject<{
   Insertion_filter: Insertion_filter;
   Insertion_orderBy: Insertion_orderBy;
   Int: ResolverTypeWrapper<Scalars['Int']>;
+  Int8: ResolverTypeWrapper<Scalars['Int8']>;
   NewCommitment: ResolverTypeWrapper<NewCommitment>;
   NewCommitment_filter: NewCommitment_filter;
   NewCommitment_orderBy: NewCommitment_orderBy;
@@ -8257,6 +8259,7 @@ export type ResolversParentTypes = ResolversObject<{
   Insertion: Insertion;
   Insertion_filter: Insertion_filter;
   Int: Scalars['Int'];
+  Int8: Scalars['Int8'];
   NewCommitment: NewCommitment;
   NewCommitment_filter: NewCommitment_filter;
   NewNullifier: NewNullifier;
@@ -8689,6 +8692,10 @@ export type InsertionResolvers<ContextType = MeshContext & { subgraphUrl: string
   transactionHash?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
+
+export interface Int8ScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Int8'], any> {
+  name: 'Int8';
+}
 
 export type NewCommitmentResolvers<ContextType = MeshContext & { subgraphUrl: string }, ParentType extends ResolversParentTypes['NewCommitment'] = ResolversParentTypes['NewCommitment']> = ResolversObject<{
   id?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
@@ -9264,6 +9271,7 @@ export type Resolvers<ContextType = MeshContext & { subgraphUrl: string }> = Res
   Encryptions?: EncryptionsResolvers<ContextType>;
   ExternalData?: ExternalDataResolvers<ContextType>;
   Insertion?: InsertionResolvers<ContextType>;
+  Int8?: GraphQLScalarType;
   NewCommitment?: NewCommitmentResolvers<ContextType>;
   NewNullifier?: NewNullifierResolvers<ContextType>;
   PublicInputs?: PublicInputsResolvers<ContextType>;
@@ -9372,7 +9380,7 @@ const additionalEnvelopPlugins: MeshPlugin<any>[] = [];
 const vanchorTransforms = [];
 const vanchorHandler = new GraphqlHandler({
               name: "vanchor",
-              config: {"endpoint":"{context.subgraphUrl:http://localhost:8000/subgraphs/name/VAnchorAthenaLocal}"},
+              config: {"endpoint":"{context.subgraphUrl:https://thegraph-backend.webb.tools/subgraphs/name/VAnchorTangle}"},
               baseDir,
               cache,
               pubsub,
@@ -9613,6 +9621,12 @@ const merger = new(BareMerger as any)({
           return printWithCache(GetVAnchorsTotalValueLockedByDateRangeDocument);
         },
         location: 'GetVAnchorsTotalValueLockedByDateRangeDocument.graphql'
+      },{
+        document: GetVAnchorLatestTvlInTimeRangeDocument,
+        get rawSDL() {
+          return printWithCache(GetVAnchorLatestTvlInTimeRangeDocument);
+        },
+        location: 'GetVAnchorLatestTvlInTimeRangeDocument.graphql'
       },{
         document: GetVAnchorTwlDocument,
         get rawSDL() {
@@ -10204,6 +10218,15 @@ export type GetVAnchorsTotalValueLockedByDateRangeQueryVariables = Exact<{
 
 
 export type GetVAnchorsTotalValueLockedByDateRangeQuery = { vanchorTotalValueLockedEveryDays: Array<Pick<VAnchorTotalValueLockedEveryDay, 'totalValueLocked' | 'vAnchorAddress' | 'startInterval' | 'endInterval'>> };
+
+export type GetVAnchorLatestTVLInTimeRangeQueryVariables = Exact<{
+  endInterval: Scalars['BigInt'];
+  startInterval: Scalars['BigInt'];
+  vAnchorAddress: Scalars['Bytes'];
+}>;
+
+
+export type GetVAnchorLatestTVLInTimeRangeQuery = { vanchorTotalValueLockedEvery15Mins: Array<Pick<VAnchorTotalValueLockedEvery15Min, 'totalValueLocked'>> };
 
 export type GetVAnchorTWLQueryVariables = Exact<{
   vAnchorAddress: Scalars['ID'];
@@ -10995,6 +11018,18 @@ export const GetVAnchorsTotalValueLockedByDateRangeDocument = gql`
   }
 }
     ` as unknown as DocumentNode<GetVAnchorsTotalValueLockedByDateRangeQuery, GetVAnchorsTotalValueLockedByDateRangeQueryVariables>;
+export const GetVAnchorLatestTVLInTimeRangeDocument = gql`
+    query GetVAnchorLatestTVLInTimeRange($endInterval: BigInt!, $startInterval: BigInt!, $vAnchorAddress: Bytes!) {
+  vanchorTotalValueLockedEvery15Mins(
+    orderBy: endInterval
+    orderDirection: desc
+    first: 1
+    where: {endInterval_lte: $endInterval, startInterval_gte: $startInterval, vAnchorAddress: $vAnchorAddress}
+  ) {
+    totalValueLocked
+  }
+}
+    ` as unknown as DocumentNode<GetVAnchorLatestTVLInTimeRangeQuery, GetVAnchorLatestTVLInTimeRangeQueryVariables>;
 export const GetVAnchorTWLDocument = gql`
     query GetVAnchorTWL($vAnchorAddress: ID!) {
   vanchorTWL(id: $vAnchorAddress) {
@@ -11574,6 +11609,7 @@ export const GetVanchorsWrappingFeeByDateRangeDocument = gql`
 
 
 
+
 export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
 export function getSdk<C, E>(requester: Requester<C, E>) {
   return {
@@ -11678,6 +11714,9 @@ export function getSdk<C, E>(requester: Requester<C, E>) {
     },
     GetVAnchorsTotalValueLockedByDateRange(variables: GetVAnchorsTotalValueLockedByDateRangeQueryVariables, options?: C): Promise<GetVAnchorsTotalValueLockedByDateRangeQuery> {
       return requester<GetVAnchorsTotalValueLockedByDateRangeQuery, GetVAnchorsTotalValueLockedByDateRangeQueryVariables>(GetVAnchorsTotalValueLockedByDateRangeDocument, variables, options) as Promise<GetVAnchorsTotalValueLockedByDateRangeQuery>;
+    },
+    GetVAnchorLatestTVLInTimeRange(variables: GetVAnchorLatestTVLInTimeRangeQueryVariables, options?: C): Promise<GetVAnchorLatestTVLInTimeRangeQuery> {
+      return requester<GetVAnchorLatestTVLInTimeRangeQuery, GetVAnchorLatestTVLInTimeRangeQueryVariables>(GetVAnchorLatestTVLInTimeRangeDocument, variables, options) as Promise<GetVAnchorLatestTVLInTimeRangeQuery>;
     },
     GetVAnchorTWL(variables: GetVAnchorTWLQueryVariables, options?: C): Promise<GetVAnchorTWLQuery> {
       return requester<GetVAnchorTWLQuery, GetVAnchorTWLQueryVariables>(GetVAnchorTWLDocument, variables, options) as Promise<GetVAnchorTWLQuery>;

--- a/packages/vanchor-client/.graphclient/schema.graphql
+++ b/packages/vanchor-client/.graphclient/schema.graphql
@@ -3483,6 +3483,12 @@ enum Insertion_orderBy {
   transactionHash
 }
 
+"""
+8 bytes signed integer
+
+"""
+scalar Int8
+
 type NewCommitment {
   id: Bytes!
   commitment: BigInt!

--- a/packages/vanchor-client/.graphclient/sources/vanchor/introspectionSchema.ts
+++ b/packages/vanchor-client/.graphclient/sources/vanchor/introspectionSchema.ts
@@ -6298,6 +6298,19 @@ const schemaAST = {
       "directives": []
     },
     {
+      "kind": "ScalarTypeDefinition",
+      "description": {
+        "kind": "StringValue",
+        "value": "8 bytes signed integer\n",
+        "block": true
+      },
+      "name": {
+        "kind": "Name",
+        "value": "Int8"
+      },
+      "directives": []
+    },
+    {
       "kind": "ObjectTypeDefinition",
       "name": {
         "kind": "Name",

--- a/packages/vanchor-client/.graphclient/sources/vanchor/schema.graphql
+++ b/packages/vanchor-client/.graphclient/sources/vanchor/schema.graphql
@@ -449,6 +449,12 @@ enum Insertion_orderBy {
   transactionHash
 }
 
+"""
+8 bytes signed integer
+
+"""
+scalar Int8
+
 type NewCommitment {
   id: Bytes!
   commitment: BigInt!

--- a/packages/vanchor-client/.graphclient/sources/vanchor/types.ts
+++ b/packages/vanchor-client/.graphclient/sources/vanchor/types.ts
@@ -19,6 +19,7 @@ export type Scalars = {
   BigDecimal: any;
   BigInt: any;
   Bytes: any;
+  Int8: any;
 };
 
 export type BlockChangedFilter = {

--- a/packages/vanchor-client/src/example-queries.ts
+++ b/packages/vanchor-client/src/example-queries.ts
@@ -2,6 +2,7 @@ import { SubgraphUrl } from './config';
 import {
   GetVAnchorsTVLByChainsByDateRange,
   GetVAnchorsTotalValueLockedByChains,
+  GetVAnchorsByChainsLatestTVLInTimeRange,
 } from './queries/tvl';
 import { GetVAnchorTWLByChainAndByToken } from './queries/twl';
 import {
@@ -26,31 +27,46 @@ import { GetVAnchorTransactionsByChains } from './queries/transaction';
 import { DateUtil } from './utils/date';
 
 const epochStart = 1692057600;
-const vAnchorAddress = '0x91eB86019FD8D7c5a9E31143D422850A13F670A3';
-const subgraphUrl = SubgraphUrl.vAnchorAthenaLocal;
-const subgraphUrl1 = SubgraphUrl.vAnchorDemeterLocal;
+const localVAnchorAddress = '0x91eB86019FD8D7c5a9E31143D422850A13F670A3';
+const liveVAnchorAddress = '0x9b5404eBc174a7eE36b0d248b2735382B320EC76';
+
+const tangleTestnetSubgraph = SubgraphUrl.vAnchorTangleTestnet;
+const liveSubgraphUrls = [
+  SubgraphUrl.vAnchorTangleTestnet,
+  SubgraphUrl.vAnchorOrbitAthena,
+  SubgraphUrl.vAnchorOrbitDemeter,
+  SubgraphUrl.vAnchorOrbitHermes,
+];
+
 const tokenSymbol = 'ETH';
 
 async function main() {
   // await getPoolOverviewTableData();
   // await getPoolWrappingTableData();
-  await getTransactions();
+  // await getTransactions();
+  await getLatestTVLByTimeRange();
 }
 
 async function getOverviewChipsData() {
   console.log(
-    await GetVAnchorsTotalValueLockedByChains([subgraphUrl], [vAnchorAddress])
+    await GetVAnchorsTotalValueLockedByChains(
+      [tangleTestnetSubgraph],
+      [localVAnchorAddress]
+    )
   );
   console.log(
-    await GetVAnchorsDepositByChains([subgraphUrl], [vAnchorAddress])
+    await GetVAnchorsDepositByChains(
+      [tangleTestnetSubgraph],
+      [localVAnchorAddress]
+    )
   );
 }
 
 async function getOverviewChartsData() {
   console.log(
     await GetVAnchorsDepositByChains15MinsInterval(
-      [subgraphUrl],
-      [vAnchorAddress],
+      [tangleTestnetSubgraph],
+      [localVAnchorAddress],
       DateUtil.fromEpochToDate(
         DateUtil.fromDateToEpoch(new Date()) - 24 * 60 * 60
       ),
@@ -59,24 +75,24 @@ async function getOverviewChartsData() {
   );
   console.log(
     await GetVAnchorsTVLByChainsByDateRange(
-      [subgraphUrl],
-      [vAnchorAddress],
+      [tangleTestnetSubgraph],
+      [localVAnchorAddress],
       epochStart,
       3
     )
   );
   console.log(
     await GetVAnchorsDepositByChainsByDateRange(
-      [subgraphUrl],
-      [vAnchorAddress],
+      [tangleTestnetSubgraph],
+      [localVAnchorAddress],
       epochStart,
       3
     )
   );
   console.log(
     await GetVAnchorsWithdrawalByChainsByDateRange(
-      [subgraphUrl],
-      [vAnchorAddress],
+      [tangleTestnetSubgraph],
+      [localVAnchorAddress],
       epochStart,
       3
     )
@@ -85,18 +101,24 @@ async function getOverviewChartsData() {
 
 async function getKeyMetricData() {
   console.log(
-    await GetVAnchorsRelayerFeeByChains([subgraphUrl], [vAnchorAddress])
+    await GetVAnchorsRelayerFeeByChains(
+      [tangleTestnetSubgraph],
+      [localVAnchorAddress]
+    )
   );
   console.log(
-    await GetVAnchorsWrappingFeeByChains([subgraphUrl], [vAnchorAddress])
+    await GetVAnchorsWrappingFeeByChains(
+      [tangleTestnetSubgraph],
+      [localVAnchorAddress]
+    )
   );
 }
 
 async function getPoolOverviewTableData() {
   console.log(
     await GetVAnchorDepositByChainAndByToken15MinsInterval(
-      subgraphUrl,
-      vAnchorAddress,
+      tangleTestnetSubgraph,
+      localVAnchorAddress,
       tokenSymbol,
       DateUtil.fromEpochToDate(
         DateUtil.fromDateToEpoch(new Date()) - 24 * 60 * 60
@@ -107,8 +129,8 @@ async function getPoolOverviewTableData() {
 
   console.log(
     await GetVAnchorWithdrawalByChainAndByToken15MinsInterval(
-      subgraphUrl1,
-      vAnchorAddress,
+      tangleTestnetSubgraph,
+      localVAnchorAddress,
       tokenSymbol,
       DateUtil.fromEpochToDate(
         DateUtil.fromDateToEpoch(new Date()) - 24 * 60 * 60
@@ -119,8 +141,8 @@ async function getPoolOverviewTableData() {
 
   console.log(
     await GetVAnchorRelayerFeeByChainAndByToken(
-      subgraphUrl,
-      vAnchorAddress,
+      tangleTestnetSubgraph,
+      localVAnchorAddress,
       tokenSymbol
     )
   );
@@ -129,16 +151,16 @@ async function getPoolOverviewTableData() {
 async function getPoolWrappingTableData() {
   console.log(
     await GetVAnchorTWLByChainAndByToken(
-      subgraphUrl,
-      vAnchorAddress,
+      tangleTestnetSubgraph,
+      localVAnchorAddress,
       tokenSymbol
     )
   );
 
   console.log(
     await GetVAnchorWrappingFeeByChainAndByToken(
-      subgraphUrl,
-      vAnchorAddress,
+      tangleTestnetSubgraph,
+      localVAnchorAddress,
       tokenSymbol
     )
   );
@@ -146,7 +168,22 @@ async function getPoolWrappingTableData() {
 
 async function getTransactions() {
   console.log(
-    await GetVAnchorTransactionsByChains([subgraphUrl], vAnchorAddress, 100)
+    await GetVAnchorTransactionsByChains(
+      [tangleTestnetSubgraph],
+      localVAnchorAddress,
+      100
+    )
+  );
+}
+
+async function getLatestTVLByTimeRange() {
+  console.log(
+    await GetVAnchorsByChainsLatestTVLInTimeRange(
+      liveSubgraphUrls,
+      [liveVAnchorAddress],
+      1692144000,
+      1694439930
+    )
   );
 }
 

--- a/packages/vanchor-client/src/graphql/tvl.graphql
+++ b/packages/vanchor-client/src/graphql/tvl.graphql
@@ -176,7 +176,7 @@ query GetVAnchorsTotalValueLockedByDateRange(
   }
 }
 
-query GetVAnchorLatestTVLInTimeRange(
+query GetVAnchorLatestTVLItemInTimeRange(
   $endInterval: BigInt!
   $startInterval: BigInt!
   $vAnchorAddress: Bytes!

--- a/packages/vanchor-client/src/graphql/tvl.graphql
+++ b/packages/vanchor-client/src/graphql/tvl.graphql
@@ -175,3 +175,22 @@ query GetVAnchorsTotalValueLockedByDateRange(
     endInterval
   }
 }
+
+query GetVAnchorLatestTVLInTimeRange(
+  $endInterval: BigInt!
+  $startInterval: BigInt!
+  $vAnchorAddress: Bytes!
+) {
+  vanchorTotalValueLockedEvery15Mins(
+    orderBy: endInterval
+    orderDirection: desc
+    first: 1
+    where: {
+      endInterval_lte: $endInterval
+      startInterval_gte: $startInterval
+      vAnchorAddress: $vAnchorAddress
+    }
+  ) {
+    totalValueLocked
+  }
+}

--- a/packages/vanchor-client/src/index.ts
+++ b/packages/vanchor-client/src/index.ts
@@ -69,6 +69,9 @@ import {
   GetVAnchorTVLByChainsByDateRange,
   GetVAnchorsTVLByChainByDateRange,
   GetVAnchorsTVLByChainsByDateRange,
+  GetVAnchorByChainLatestTVLInTimeRange,
+  GetVAnchorsByChainLatestTVLInTimeRange,
+  GetVAnchorsByChainsLatestTVLInTimeRange,
 } from './queries/tvl';
 import {
   GetVAnchorTWLByChain,
@@ -246,6 +249,9 @@ const vAnchorClient = {
     GetVAnchorTVLByChainsByDateRange,
     GetVAnchorsTVLByChainByDateRange,
     GetVAnchorsTVLByChainsByDateRange,
+    GetVAnchorByChainLatestTVLInTimeRange,
+    GetVAnchorsByChainLatestTVLInTimeRange,
+    GetVAnchorsByChainsLatestTVLInTimeRange,
   },
   TWL: {
     GetVAnchorTWLByChain,

--- a/packages/vanchor-client/src/queries/tvl/tvl15MinsInterval.ts
+++ b/packages/vanchor-client/src/queries/tvl/tvl15MinsInterval.ts
@@ -219,7 +219,7 @@ export const GetVAnchorByChainLatestTVLInTimeRange = async (
   startInterval: number,
   endInterval: number
 ): Promise<LatestTVLUpdate> => {
-  const result = await sdk.GetVAnchorLatestTVLInTimeRange(
+  const tvlLatestItem = await sdk.GetVAnchorLatestTVLItemInTimeRange(
     {
       vAnchorAddress: vAnchorAddress.toLowerCase(),
       startInterval,
@@ -230,7 +230,7 @@ export const GetVAnchorByChainLatestTVLInTimeRange = async (
     }
   );
 
-  if (!result.vanchorTotalValueLockedEvery15Mins?.length) {
+  if (!tvlLatestItem.vanchorTotalValueLockedEvery15Mins?.length) {
     return {
       vAnchorAddress,
       totalValueLocked: null,
@@ -241,7 +241,8 @@ export const GetVAnchorByChainLatestTVLInTimeRange = async (
   return {
     vAnchorAddress,
     totalValueLocked: BigInt(
-      result.vanchorTotalValueLockedEvery15Mins[0].totalValueLocked
+      // there's only one item returned from the query
+      tvlLatestItem.vanchorTotalValueLockedEvery15Mins[0].totalValueLocked
     ),
     subgraphUrl,
   };


### PR DESCRIPTION
There is no effective way to get the 24h tvl data for Hubble Stats UI at the moment.

This PR adds new query functions that allow us to get the latest data based on a given start and end interval. 
For example for getting 24h data: getting the latest 15mins interval item from epoch to the exact timestamp from 24h ago (this approach makes sure we still can get data if there are no transactions in several days)